### PR TITLE
v6.0 - "Command Forge"

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,18 @@ Run with session logging disabled:
 ./hash-cracker.sh --no-session-log
 ```
 
+Export stats JSON to a file:
+
+```bash
+./hash-cracker.sh --stats-export /tmp/hash-cracker-stats.json
+```
+
+Export stats JSON with full log history:
+
+```bash
+./hash-cracker.sh --stats-export /tmp/hash-cracker-stats.json --stats-export-scope all
+```
+
 Run non-interactive health checks:
 
 ```bash
@@ -175,6 +187,8 @@ By default, `hash-cracker` enables optimized kernels, enables loopback, disables
 - `--no-session-log` - disable session stats logging to file
 - `--session-log-keep [N]`, `--session-log-keep=N` - keep last `N` auto-created session logs in `logs/` (default: `0`, no pruning)
 - `--stats-debug` - print whether stats refresh used incremental update or full recount
+- `--stats-export [PATH]`, `--stats-export=PATH` - export machine-readable session stats JSON to `PATH`
+- `--stats-export-scope [latest|all]`, `--stats-export-scope=...` - export latest snapshot only (`latest`, default) or include all parsed entries from `logs/session-*.log` (`all`)
 - `--job [ID]`, `--job=ID` - run one menu option non-interactively and exit (supports `1-22` and `99`)
 - `--list-jobs` - print available job IDs and exit
 - `--self-test`, `--doctor` - run non-interactive configuration and dependency checks, then exit with status code
@@ -239,6 +253,9 @@ When the tool starts successfully, it opens an interactive menu with these optio
   - Override path with `SESSION_STATS_LOGFILE`
   - Set `--no-session-log` to disable file logging
 - With `--stats-debug`, the tool prints which refresh path was used (`incremental` or `full recount`).
+- With `--stats-export`, current stats are written as JSON on each refresh cycle.
+- With `--stats-export-scope latest` (default), JSON contains the latest snapshot only.
+- With `--stats-export-scope all`, JSON also includes parsed history from `logs/session-*.log`.
 
 ## Example Hashes
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ When the tool starts successfully, it opens an interactive menu with these optio
   - Set `--no-session-log` to disable file logging
 - With `--stats-debug`, the tool prints which refresh path was used (`incremental` or `full recount`).
 - With `--stats-export`, current stats are written as JSON on each refresh cycle.
+- Exported JSON includes a top-level `"schema_version"` for stable downstream parsing.
 - With `--stats-export-scope latest` (default), JSON contains the latest snapshot only.
 - With `--stats-export-scope all`, JSON also includes parsed history from `logs/session-*.log`.
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ By default, `hash-cracker` enables optimized kernels, enables loopback, disables
 - `--dry-run` - print the resolved hashcat commands without executing them; preprocessor file/tool actions are reported and skipped
 - `--no-session-log` - disable session stats logging to file
 - `--session-log-keep [N]`, `--session-log-keep=N` - keep last `N` auto-created session logs in `logs/` (default: `0`, no pruning)
+- `--stats-debug` - print whether stats refresh used incremental update or full recount
 - `--job [ID]`, `--job=ID` - run one menu option non-interactively and exit (supports `1-22` and `99`)
 - `--list-jobs` - print available job IDs and exit
 - `--self-test`, `--doctor` - run non-interactive configuration and dependency checks, then exit with status code
@@ -237,6 +238,7 @@ When the tool starts successfully, it opens an interactive menu with these optio
   - Set `--session-log-keep [N]` to tune retention
   - Override path with `SESSION_STATS_LOGFILE`
   - Set `--no-session-log` to disable file logging
+- With `--stats-debug`, the tool prints which refresh path was used (`incremental` or `full recount`).
 
 ## Example Hashes
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ Run in dry-run mode:
 ./hash-cracker.sh --dry-run
 ```
 
+List available jobs and exit:
+
+```bash
+./hash-cracker.sh --list-jobs
+```
+
+Run one job non-interactively:
+
+```bash
+./hash-cracker.sh --job 8
+```
+
 Run with session logging disabled:
 
 ```bash
@@ -162,6 +174,8 @@ By default, `hash-cracker` enables optimized kernels, enables loopback, disables
 - `--dry-run` - print the resolved hashcat commands without executing them; preprocessor file/tool actions are reported and skipped
 - `--no-session-log` - disable session stats logging to file
 - `--session-log-keep [N]`, `--session-log-keep=N` - keep last `N` auto-created session logs in `logs/` (default: `0`, no pruning)
+- `--job [ID]`, `--job=ID` - run one menu option non-interactively and exit (supports `1-22` and `99`)
+- `--list-jobs` - print available job IDs and exit
 - `--self-test`, `--doctor` - run non-interactive configuration and dependency checks, then exit with status code
 
 ## Menu Options
@@ -202,6 +216,8 @@ When the tool starts successfully, it opens an interactive menu with these optio
 - Option `17` can generate candidates from either the potfile or a selected wordlist.
 - Option `18` prompts for a URL, output wordlist name, spider depth, and minimum word length.
 - Option `21` prompts for brute-force length and whether increment mode should be enabled.
+- `--job` mode runs selected options directly without entering the interactive menu.
+- In non-interactive contexts, prompt-dependent jobs (for example `4`, `5`, `8`, `15`, `17`, `18`, `21`, `22`) fail fast with a clear message.
 
 ## Runtime Status Output
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,25 @@
 # Version log
 
+## v6.0 - Command Forge
+
+### Highlights
+
+- Added first-class non-interactive execution for automation workflows.
+
+### Added
+
+- New flag: `--list-jobs`
+  - Prints available job IDs and descriptions, then exits.
+- New flag: `--job [ID]` (also supports `--job=ID`)
+  - Runs a single option non-interactively and exits.
+  - Supports all menu jobs `1-22` and dashboard `99`.
+
+### Changed
+
+- Startup and dashboard release label updated to `v6.0 "Command Forge"`.
+- Non-interactive job runs now reuse existing dependency validation and session-stats logging behavior.
+- Prompt-dependent jobs now fail fast in non-interactive `--job` mode with clear guidance.
+
 ## v5.1.3 - Iron Pulse
 
 ### Highlights

--- a/VERSION.md
+++ b/VERSION.md
@@ -15,6 +15,11 @@
   - Supports all menu jobs `1-22` and dashboard `99`.
 - New flag: `--stats-debug`
   - Prints whether session stats refresh used incremental update or full recount.
+- New flag: `--stats-export [PATH]` (also supports `--stats-export=PATH`)
+  - Exports machine-readable session stats as JSON on each refresh cycle.
+- New flag: `--stats-export-scope [latest|all]` (also supports `--stats-export-scope=...`)
+  - `latest` (default): exports only the current snapshot JSON.
+  - `all`: includes parsed history entries from `logs/session-*.log` in JSON output.
 
 ### Changed
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -27,6 +27,7 @@
 - Non-interactive job runs now reuse existing dependency validation and session-stats logging behavior.
 - Prompt-dependent jobs now fail fast in non-interactive `--job` mode with clear guidance.
 - Session stats unique-count refresh now uses incremental cache updates on append growth, with automatic full-recount fallback on non-append changes.
+- Stats export JSON now includes top-level `"schema_version": "1"` for downstream compatibility checks.
 
 ## v5.1.3 - Iron Pulse
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -13,12 +13,15 @@
 - New flag: `--job [ID]` (also supports `--job=ID`)
   - Runs a single option non-interactively and exits.
   - Supports all menu jobs `1-22` and dashboard `99`.
+- New flag: `--stats-debug`
+  - Prints whether session stats refresh used incremental update or full recount.
 
 ### Changed
 
 - Startup and dashboard release label updated to `v6.0 "Command Forge"`.
 - Non-interactive job runs now reuse existing dependency validation and session-stats logging behavior.
 - Prompt-dependent jobs now fail fast in non-interactive `--job` mode with clear guidance.
+- Session stats unique-count refresh now uses incremental cache updates on append growth, with automatic full-recount fallback on non-append changes.
 
 ## v5.1.3 - Iron Pulse
 

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -49,13 +49,21 @@ function banner_center_line() {
     printf '│ %*s%s%*s │\n' "$pad_left" '' "$clipped" "$pad_right" ''
 }
 
+function release_version_text() {
+    printf '%s' 'v6.0 "Command Forge"'
+}
+
+function release_label_text() {
+    printf 'hash-cracker %s' "$(release_version_text)"
+}
+
 function hash-cracker() {
     local status_text
     local version_text
     local progress_text
 
     status_text="status: ${BANNER_STATUS:-cracking salted secrets}"
-    version_text='v5.1.3 "Iron Pulse"'
+    version_text="$(release_version_text)"
     progress_text="[██████████████████░░░░] 82%"
 
     cat <<'EOF'
@@ -103,6 +111,15 @@ function menu_entries() {
 21|Custom brute force|scripts/processors/21-custom-brute-force.sh
 22|Directory of word lists plain and then with buka_400k|scripts/processors/22-multiple-wordlists-buka.sh
 EOF
+}
+
+function print_job_list() {
+    local option_id option_text processor
+
+    while IFS='|' read -r option_id option_text processor; do
+        echo "$option_id. $option_text"
+    done < <(menu_entries)
+    echo "99. Session stats dashboard"
 }
 
 function dependency_fail() {
@@ -396,7 +413,7 @@ function show_session_stats_dashboard() {
     local log_state
     local keep_count
     local log_path
-    local release_text='hash-cracker v5.1.3 "Iron Pulse"'
+    local release_text
 
     if [ "${SESSION_LOG_DISABLED:-0}" = '1' ]; then
         log_state="disabled"
@@ -406,11 +423,12 @@ function show_session_stats_dashboard() {
 
     keep_count=$(session_log_keep_count)
     log_path="${SESSION_STATS_LOGFILE:-n/a}"
+    release_text="$(release_label_text)"
     session_stats_line="new $(signed_num "$SESSION_NEW_CRACKS") lines, $(signed_num "$SESSION_NEW_UNIQUE") unique, $(signed_num "$SESSION_GROWTH_BYTES") bytes"
 
     echo
     echo "+--------------------------------------+--------------------------------------------------------+"
-    echo "| Session Stats Dashboard              | hash-cracker v5.1.3 \"Iron Pulse\"                      |"
+    dashboard_line "Session Stats Dashboard" "$(release_label_text)"
     echo "+--------------------------------------+--------------------------------------------------------+"
     dashboard_line "Generated at" "$(timestamp_now)"
     dashboard_line "Release" "$release_text"
@@ -427,6 +445,15 @@ function show_session_stats_dashboard() {
     dashboard_line "Session log file" "$log_path"
     echo "+--------------------------------------+--------------------------------------------------------+"
     echo
+}
+
+function build_session_stats_line() {
+    printf 'Session stats: new %s lines, %s unique, %s bytes | total cracked passwords in potfile: %s lines | input hashes: %s unique' \
+        "$(signed_num "$SESSION_NEW_CRACKS")" \
+        "$(signed_num "$SESSION_NEW_UNIQUE")" \
+        "$(signed_num "$SESSION_GROWTH_BYTES")" \
+        "$SESSION_POT_LINES_CUR" \
+        "$SESSION_HASHLIST_INPUT_UNIQUE"
 }
 
 function init_session_stats() {
@@ -540,6 +567,48 @@ function run_self_test() {
     return 0
 }
 
+function run_single_job_mode() {
+    local selected="$1"
+    local rc
+    local session_stats_line
+
+    refresh_session_stats
+    session_stats_line=$(build_session_stats_line)
+    log_session_stats_line "$session_stats_line"
+
+    if [ "$selected" = "99" ]; then
+        show_session_stats_dashboard
+        return 0
+    fi
+
+    case "$selected" in
+        4 | 5 | 8 | 15 | 17 | 18 | 21 | 22)
+            if [ ! -t 0 ]; then
+                status_error "Job $selected requires interactive input and cannot run in non-interactive --job mode."
+                status_heading "Use --list-jobs and choose a non-prompting job, or run interactively."
+                return 1
+            fi
+            ;;
+    esac
+
+    if ! check_job_dependencies "$selected"; then
+        return 1
+    fi
+
+    if ! run_processor "$selected"; then
+        status_error "Invalid job selection for --job: $selected"
+        status_heading "Use --list-jobs to see available options."
+        return 1
+    fi
+    rc=$?
+
+    refresh_session_stats
+    session_stats_line=$(build_session_stats_line)
+    log_session_stats_line "$session_stats_line"
+
+    return $rc
+}
+
 function menu() {
     local option_id option_text processor
     local session_stats_line
@@ -547,12 +616,9 @@ function menu() {
     while true; do
         refresh_session_stats
         echo -e "\n0. Exit"
-        while IFS='|' read -r option_id option_text processor; do
-            echo "$option_id. $option_text"
-        done < <(menu_entries)
-        echo "99. Session stats dashboard"
+        print_job_list
         echo
-        session_stats_line="Session stats: new $(signed_num "$SESSION_NEW_CRACKS") lines, $(signed_num "$SESSION_NEW_UNIQUE") unique, $(signed_num "$SESSION_GROWTH_BYTES") bytes | total cracked passwords in potfile: $SESSION_POT_LINES_CUR lines | input hashes: $SESSION_HASHLIST_INPUT_UNIQUE unique"
+        session_stats_line=$(build_session_stats_line)
         log_session_stats_line "$session_stats_line"
 
         if [ "$DRYRUN" = ' ' ]; then
@@ -597,9 +663,20 @@ source scripts/parameters.sh "$@"
 status_heading "Preparing session stats (counting potfile and input hashes)..."
 init_session_stats
 
+if [ "$JOBLIST" = ' ' ]; then
+    print_job_list
+    exit 0
+fi
+
 if [ "$SELFTEST" = ' ' ]; then
     run_self_test
     exit $?
 fi
 
+if [ -n "${JOBMODE:-}" ]; then
+    run_single_job_mode "$JOBMODE"
+    exit $?
+fi
+
 menu "$@"
+release_text="$(release_label_text)"

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -313,6 +313,56 @@ function count_hashlist_unique_entries() {
     fi
 }
 
+function cleanup_session_state() {
+    if [ -n "${SESSION_POT_UNIQUE_CACHE:-}" ]; then
+        rm -f -- "$SESSION_POT_UNIQUE_CACHE" 2>/dev/null || true
+    fi
+}
+
+function rebuild_unique_plaintext_cache() {
+    if [ -f "$POTFILE" ]; then
+        awk -F: 'NF {print $NF}' "$POTFILE" | LC_ALL=C sort -u >"$SESSION_POT_UNIQUE_CACHE"
+    else
+        : >"$SESSION_POT_UNIQUE_CACHE"
+    fi
+    SESSION_POT_UNIQUE_CUR=$(wc -l <"$SESSION_POT_UNIQUE_CACHE" | tr -d '[:space:]')
+    stats_debug_note "Stats refresh mode: full recount (unique plaintext cache rebuilt: $SESSION_POT_UNIQUE_CUR)"
+}
+
+function update_unique_plaintexts_incremental() {
+    local delta_lines="$1"
+    local tmp_delta
+    local tmp_merge
+    local new_unique_lines
+
+    if [ "$delta_lines" -le 0 ]; then
+        return 0
+    fi
+
+    tmp_delta="$(mktemp /tmp/hash-cracker-unique-delta.XXXX)"
+    tmp_merge="$(mktemp /tmp/hash-cracker-unique-merge.XXXX)"
+
+    tail -n "$delta_lines" "$POTFILE" | awk -F: 'NF {print $NF}' | LC_ALL=C sort -u >"$tmp_delta"
+    if [ ! -s "$tmp_delta" ]; then
+        rm -f -- "$tmp_delta" "$tmp_merge"
+        return 0
+    fi
+
+    if [ ! -f "$SESSION_POT_UNIQUE_CACHE" ]; then
+        : >"$SESSION_POT_UNIQUE_CACHE"
+    fi
+
+    new_unique_lines=$(comm -13 "$SESSION_POT_UNIQUE_CACHE" "$tmp_delta" | wc -l | tr -d '[:space:]')
+    if [ "$new_unique_lines" -gt 0 ]; then
+        cat "$SESSION_POT_UNIQUE_CACHE" "$tmp_delta" | LC_ALL=C sort -u >"$tmp_merge"
+        mv "$tmp_merge" "$SESSION_POT_UNIQUE_CACHE"
+        SESSION_POT_UNIQUE_CUR=$((SESSION_POT_UNIQUE_CUR + new_unique_lines))
+    fi
+    stats_debug_note "Stats refresh mode: incremental (delta lines: $delta_lines, new unique plaintexts: $new_unique_lines)"
+
+    rm -f -- "$tmp_delta" "$tmp_merge"
+}
+
 function signed_num() {
     local value="$1"
     if [ "$value" -ge 0 ]; then
@@ -324,6 +374,16 @@ function signed_num() {
 
 function timestamp_now() {
     date '+%Y-%m-%d %H:%M:%S%z'
+}
+
+function stats_debug_enabled() {
+    [ "$STATSDEBUG" = ' ' ]
+}
+
+function stats_debug_note() {
+    if stats_debug_enabled; then
+        status_heading "$1"
+    fi
 }
 
 function session_log_keep_count() {
@@ -423,7 +483,7 @@ function show_session_stats_dashboard() {
 
     keep_count=$(session_log_keep_count)
     log_path="${SESSION_STATS_LOGFILE:-n/a}"
-    release_text="$(release_label_text)"
+    release_text="$(release_version_text)"
     session_stats_line="new $(signed_num "$SESSION_NEW_CRACKS") lines, $(signed_num "$SESSION_NEW_UNIQUE") unique, $(signed_num "$SESSION_GROWTH_BYTES") bytes"
 
     echo
@@ -438,7 +498,6 @@ function show_session_stats_dashboard() {
     dashboard_line "Session delta" "$session_stats_line"
     dashboard_line "Total cracked lines in potfile" "$SESSION_POT_LINES_CUR"
     dashboard_line "Total unique plaintexts in potfile" "$SESSION_POT_UNIQUE_CUR"
-    dashboard_line "Total potfile bytes" "$SESSION_POT_BYTES_CUR"
     dashboard_line "Unique input hashes" "$SESSION_HASHLIST_INPUT_UNIQUE"
     dashboard_line "Session logging" "$log_state"
     dashboard_line "Session log keep" "$keep_count"
@@ -459,11 +518,11 @@ function build_session_stats_line() {
 function init_session_stats() {
     SESSION_POT_LINES_BASE=$(count_file_lines "$POTFILE")
     SESSION_POT_BYTES_BASE=$(count_file_bytes "$POTFILE")
-    SESSION_POT_UNIQUE_BASE=$(count_potfile_unique_plaintexts)
+    SESSION_POT_UNIQUE_BASE=0
 
     SESSION_POT_LINES_CUR="$SESSION_POT_LINES_BASE"
     SESSION_POT_BYTES_CUR="$SESSION_POT_BYTES_BASE"
-    SESSION_POT_UNIQUE_CUR="$SESSION_POT_UNIQUE_BASE"
+    SESSION_POT_UNIQUE_CUR=0
 
     SESSION_POT_LINES_LAST="$SESSION_POT_LINES_CUR"
     SESSION_POT_BYTES_LAST="$SESSION_POT_BYTES_CUR"
@@ -474,16 +533,26 @@ function init_session_stats() {
 
     SESSION_HASHLIST_PATH_LAST="$HASHLIST"
     SESSION_HASHLIST_INPUT_UNIQUE=$(count_hashlist_unique_entries)
+    SESSION_POT_UNIQUE_CACHE="/tmp/hash-cracker-unique-${BASHPID}.cache"
+    rebuild_unique_plaintext_cache
+    SESSION_POT_UNIQUE_BASE="$SESSION_POT_UNIQUE_CUR"
     init_session_stats_logfile
 }
 
 function refresh_session_stats() {
+    local delta_lines
+
     SESSION_POT_LINES_CUR=$(count_file_lines "$POTFILE")
     SESSION_POT_BYTES_CUR=$(count_file_bytes "$POTFILE")
 
     if [ "$SESSION_POT_LINES_CUR" -ne "$SESSION_POT_LINES_LAST" ] || [ "$SESSION_POT_BYTES_CUR" -ne "$SESSION_POT_BYTES_LAST" ]; then
-        status_heading "Refreshing session stats (recounting unique potfile plaintexts, this may take a moment)..."
-        SESSION_POT_UNIQUE_CUR=$(count_potfile_unique_plaintexts)
+        if [ "$SESSION_POT_LINES_CUR" -ge "$SESSION_POT_LINES_LAST" ] && [ "$SESSION_POT_BYTES_CUR" -ge "$SESSION_POT_BYTES_LAST" ]; then
+            delta_lines=$((SESSION_POT_LINES_CUR - SESSION_POT_LINES_LAST))
+            update_unique_plaintexts_incremental "$delta_lines"
+        else
+            status_heading "Refreshing session stats (recounting unique potfile plaintexts, this may take a moment)..."
+            rebuild_unique_plaintext_cache
+        fi
         SESSION_POT_LINES_LAST="$SESSION_POT_LINES_CUR"
         SESSION_POT_BYTES_LAST="$SESSION_POT_BYTES_CUR"
     fi
@@ -659,6 +728,7 @@ function menu() {
 }
 
 init_colors
+trap cleanup_session_state EXIT
 source scripts/parameters.sh "$@"
 status_heading "Preparing session stats (counting potfile and input hashes)..."
 init_session_stats

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -509,6 +509,7 @@ function export_session_stats_json() {
 
     cat >"$tmp_path" <<EOF
 {
+  "schema_version": "1",
   "generated_at": "$(json_escape "$generated_at")",
   "export_scope": "$(json_escape "$export_scope")",
   "release": "$(json_escape "$release_label")",

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -386,6 +386,160 @@ function stats_debug_note() {
     fi
 }
 
+function json_escape() {
+    local s="$1"
+    s=${s//\\/\\\\}
+    s=${s//\"/\\\"}
+    s=${s//$'\n'/\\n}
+    s=${s//$'\r'/\\r}
+    s=${s//$'\t'/\\t}
+    printf '%s' "$s"
+}
+
+function ensure_parent_dir() {
+    local path="$1"
+    local parent
+
+    parent=$(dirname "$path")
+    if [ -n "$parent" ] && [ "$parent" != "." ]; then
+        mkdir -p "$parent" 2>/dev/null || true
+    fi
+}
+
+function stats_export_scope() {
+    local scope="${STATSEXPORT_SCOPE:-latest}"
+    case "$scope" in
+        latest | all) printf '%s' "$scope" ;;
+        *) printf 'latest' ;;
+    esac
+}
+
+function export_session_stats_history_json() {
+    local logs_dir='logs'
+    local first='1'
+    local file
+    local line
+    local timestamp
+    local message
+    local new_lines
+    local new_unique
+    local growth_bytes
+    local total_lines
+    local input_unique
+
+    printf '['
+
+    if [ -d "$logs_dir" ]; then
+        while IFS= read -r file; do
+            while IFS= read -r line; do
+                if [[ "$line" =~ ^\[([^]]+)\][[:space:]](.*)$ ]]; then
+                    timestamp="${BASH_REMATCH[1]}"
+                    message="${BASH_REMATCH[2]}"
+                else
+                    timestamp=''
+                    message="$line"
+                fi
+
+                if [ "$first" = '1' ]; then
+                    first='0'
+                else
+                    printf ','
+                fi
+
+                if [[ "$message" =~ ^Session\ stats:\ new\ ([+-]?[0-9]+)\ lines,\ ([+-]?[0-9]+)\ unique,\ ([+-]?[0-9]+)\ bytes\ \|\ total\ cracked\ passwords\ in\ potfile:\ ([0-9]+)\ lines\ \|\ input\ hashes:\ ([0-9]+)\ unique$ ]]; then
+                    new_lines="${BASH_REMATCH[1]}"
+                    new_unique="${BASH_REMATCH[2]}"
+                    growth_bytes="${BASH_REMATCH[3]}"
+                    total_lines="${BASH_REMATCH[4]}"
+                    input_unique="${BASH_REMATCH[5]}"
+                    printf '\n    { "timestamp": "%s", "source": "%s", "message": "%s", "session": { "new_cracks_lines": %s, "new_unique": %s, "growth_bytes": %s }, "potfile": { "total_cracked_lines": %s }, "input_hashes": { "unique": %s } }' \
+                        "$(json_escape "$timestamp")" \
+                        "$(json_escape "$file")" \
+                        "$(json_escape "$message")" \
+                        "$new_lines" \
+                        "$new_unique" \
+                        "$growth_bytes" \
+                        "$total_lines" \
+                        "$input_unique"
+                else
+                    printf '\n    { "timestamp": "%s", "source": "%s", "message": "%s" }' \
+                        "$(json_escape "$timestamp")" \
+                        "$(json_escape "$file")" \
+                        "$(json_escape "$message")"
+                fi
+            done <"$file"
+        done < <(find "$logs_dir" -maxdepth 1 -type f -name 'session-*.log' -print | LC_ALL=C sort)
+    fi
+
+    if [ "$first" = '0' ]; then
+        printf '\n  '
+    fi
+    printf ']'
+}
+
+function export_session_stats_json() {
+    local out_path="${STATSEXPORT:-}"
+    local tmp_path
+    local log_enabled
+    local release_label
+    local generated_at
+    local export_scope
+    local history_json
+
+    if [ -z "$out_path" ]; then
+        return 0
+    fi
+
+    ensure_parent_dir "$out_path"
+
+    if [ "${SESSION_LOG_DISABLED:-0}" = '1' ]; then
+        log_enabled="false"
+    else
+        log_enabled="true"
+    fi
+
+    release_label="$(release_version_text)"
+    generated_at="$(timestamp_now)"
+    export_scope="$(stats_export_scope)"
+    history_json='[]'
+    if [ "$export_scope" = 'all' ]; then
+        history_json="$(export_session_stats_history_json)"
+    fi
+    tmp_path="${out_path}.tmp.$$"
+
+    cat >"$tmp_path" <<EOF
+{
+  "generated_at": "$(json_escape "$generated_at")",
+  "export_scope": "$(json_escape "$export_scope")",
+  "release": "$(json_escape "$release_label")",
+  "hashtype": "$(json_escape "${HASHTYPE_DISPLAY:-$HASHTYPE}")",
+  "hashlist": "$(json_escape "$HASHLIST")",
+  "potfile": "$(json_escape "$POTFILE")",
+  "session": {
+    "new_cracks_lines": $SESSION_NEW_CRACKS,
+    "new_unique": $SESSION_NEW_UNIQUE,
+    "growth_bytes": $SESSION_GROWTH_BYTES
+  },
+  "potfile_totals": {
+    "lines": $SESSION_POT_LINES_CUR,
+    "unique_plaintexts": $SESSION_POT_UNIQUE_CUR,
+    "bytes": $SESSION_POT_BYTES_CUR
+  },
+  "input_hashes": {
+    "unique": $SESSION_HASHLIST_INPUT_UNIQUE
+  },
+  "logging": {
+    "enabled": $log_enabled,
+    "keep": $(session_log_keep_count),
+    "path": "$(json_escape "${SESSION_STATS_LOGFILE:-}")"
+  },
+  "history": $history_json
+}
+EOF
+
+    mv "$tmp_path" "$out_path" 2>/dev/null || true
+}
+
 function session_log_keep_count() {
     case "${SESSION_LOG_KEEP:-}" in
         '' | *[!0-9]*) echo 0 ;;
@@ -502,6 +656,7 @@ function show_session_stats_dashboard() {
     dashboard_line "Session logging" "$log_state"
     dashboard_line "Session log keep" "$keep_count"
     dashboard_line "Session log file" "$log_path"
+    dashboard_line "Stats export file" "${STATSEXPORT:-n/a}"
     echo "+--------------------------------------+--------------------------------------------------------+"
     echo
 }
@@ -644,6 +799,7 @@ function run_single_job_mode() {
     refresh_session_stats
     session_stats_line=$(build_session_stats_line)
     log_session_stats_line "$session_stats_line"
+    export_session_stats_json
 
     if [ "$selected" = "99" ]; then
         show_session_stats_dashboard
@@ -674,6 +830,7 @@ function run_single_job_mode() {
     refresh_session_stats
     session_stats_line=$(build_session_stats_line)
     log_session_stats_line "$session_stats_line"
+    export_session_stats_json
 
     return $rc
 }
@@ -689,6 +846,7 @@ function menu() {
         echo
         session_stats_line=$(build_session_stats_line)
         log_session_stats_line "$session_stats_line"
+        export_session_stats_json
 
         if [ "$DRYRUN" = ' ' ]; then
             read -r -p "Select job [0-22,99] or type exit [DRY-RUN MODE]: " START

--- a/scripts/parameters.sh
+++ b/scripts/parameters.sh
@@ -3,7 +3,7 @@
 
 if [ "$1" == '-h' ] || [ "$1" == '--help' ]; then
     echo -e "Note: flags are optional, by default hash-cracker will run with optimized kernels enabled and perform loopback actions."
-    echo -e "\nUsage: ./hash-cracker [FLAG]"
+    echo -e "\nUsage: ./hash-cracker.sh [FLAG]"
     echo -e "\nFlags:"
     echo -e "\t-l / --no-loopback\n\t\t Disable loopback functionality"
     echo -e "\t-n / --no-limit\n\t\t Disable the use of optimized kernels (un-limits password length)"

--- a/scripts/parameters.sh
+++ b/scripts/parameters.sh
@@ -15,6 +15,8 @@ if [ "$1" == '-h' ] || [ "$1" == '--help' ]; then
     echo -e "\t--no-session-log\n\t\t Disable session stats logging to file"
     echo -e "\t--session-log-keep [N]\n\t\t Keep last N auto-created session logs in logs/ (default: 0, no pruning)"
     echo -e "\t--stats-debug\n\t\t Print how session stats are refreshed (incremental vs full recount)"
+    echo -e "\t--stats-export [PATH]\n\t\t Export machine-readable session stats JSON to PATH"
+    echo -e "\t--stats-export-scope [latest|all]\n\t\t Export latest snapshot only or all entries from logs (default: latest)"
     echo -e "\t--job [ID]\n\t\t Run one menu option non-interactively (supports 1-22 and 99)"
     echo -e "\t--list-jobs\n\t\t Print available job IDs and exit"
     echo -e "\t--self-test / --doctor\n\t\t Run non-interactive dependency and configuration checks, then exit"
@@ -64,6 +66,43 @@ while [[ "$#" -gt 0 ]]; do
         --dry-run) DRYRUN=' ' ;;
         --no-session-log) SESSION_LOG_DISABLED='1' ;;
         --stats-debug) STATSDEBUG=' ' ;;
+        --stats-export)
+            if [ -z "${2:-}" ]; then
+                status_error "Missing value for --stats-export. Provide a file path."
+                exit 1
+            fi
+            STATSEXPORT="$2"
+            shift
+            ;;
+        --stats-export=*)
+            STATSEXPORT="${1#*=}"
+            if [ -z "$STATSEXPORT" ]; then
+                status_error "Missing value for --stats-export. Provide a file path."
+                exit 1
+            fi
+            ;;
+        --stats-export-scope)
+            case "${2:-}" in
+                latest | all)
+                    STATSEXPORT_SCOPE="$2"
+                    shift
+                    ;;
+                *)
+                    status_error "Invalid value for --stats-export-scope. Use 'latest' or 'all'."
+                    exit 1
+                    ;;
+            esac
+            ;;
+        --stats-export-scope=*)
+            STATSEXPORT_SCOPE="${1#*=}"
+            case "$STATSEXPORT_SCOPE" in
+                latest | all) ;;
+                *)
+                    status_error "Invalid value for --stats-export-scope. Use 'latest' or 'all'."
+                    exit 1
+                    ;;
+            esac
+            ;;
         --job)
             case "${2:-}" in
                 '' | *[!0-9]*)
@@ -284,6 +323,11 @@ fi
 
 if [ "$STATSDEBUG" = ' ' ]; then
     status_ok "Stats debug output enabled"
+fi
+
+if [ -n "${STATSEXPORT:-}" ]; then
+    status_ok "Stats export enabled: $STATSEXPORT"
+    status_ok "Stats export scope: ${STATSEXPORT_SCOPE:-latest}"
 fi
 
 if [ "$JOBLIST" = ' ' ]; then

--- a/scripts/parameters.sh
+++ b/scripts/parameters.sh
@@ -14,6 +14,8 @@ if [ "$1" == '-h' ] || [ "$1" == '--help' ]; then
     echo -e "\t--dry-run\n\t\t Print hashcat commands without executing them"
     echo -e "\t--no-session-log\n\t\t Disable session stats logging to file"
     echo -e "\t--session-log-keep [N]\n\t\t Keep last N auto-created session logs in logs/ (default: 0, no pruning)"
+    echo -e "\t--job [ID]\n\t\t Run one menu option non-interactively (supports 1-22 and 99)"
+    echo -e "\t--list-jobs\n\t\t Print available job IDs and exit"
     echo -e "\t--self-test / --doctor\n\t\t Run non-interactive dependency and configuration checks, then exit"
     exit 1
 elif [ "$1" == '-m' ] || [ "$1" == '--module-info' ]; then
@@ -60,6 +62,28 @@ while [[ "$#" -gt 0 ]]; do
         -d | --disable-cracked) SHOWCRACKED=' ' ;;
         --dry-run) DRYRUN=' ' ;;
         --no-session-log) SESSION_LOG_DISABLED='1' ;;
+        --job)
+            case "${2:-}" in
+                '' | *[!0-9]*)
+                    status_error "Invalid value for --job. Expected a numeric job ID."
+                    exit 1
+                    ;;
+                *)
+                    JOBMODE="$2"
+                    shift
+                    ;;
+            esac
+            ;;
+        --job=*)
+            JOBMODE="${1#*=}"
+            case "$JOBMODE" in
+                '' | *[!0-9]*)
+                    status_error "Invalid value for --job. Expected a numeric job ID."
+                    exit 1
+                    ;;
+            esac
+            ;;
+        --list-jobs) JOBLIST=' ' ;;
         --session-log-keep)
             case "${2:-}" in
                 '' | *[!0-9]*)
@@ -254,6 +278,14 @@ else
     else
         status_ok "Session log retention: keeping last $SESSION_LOG_KEEP_EFFECTIVE file(s)"
     fi
+fi
+
+if [ "$JOBLIST" = ' ' ]; then
+    status_ok "Job listing mode enabled"
+fi
+
+if [ -n "${JOBMODE:-}" ]; then
+    status_ok "Non-interactive job mode enabled: job $JOBMODE"
 fi
 
 echo -e "\nStatic parameters:"

--- a/scripts/parameters.sh
+++ b/scripts/parameters.sh
@@ -14,6 +14,7 @@ if [ "$1" == '-h' ] || [ "$1" == '--help' ]; then
     echo -e "\t--dry-run\n\t\t Print hashcat commands without executing them"
     echo -e "\t--no-session-log\n\t\t Disable session stats logging to file"
     echo -e "\t--session-log-keep [N]\n\t\t Keep last N auto-created session logs in logs/ (default: 0, no pruning)"
+    echo -e "\t--stats-debug\n\t\t Print how session stats are refreshed (incremental vs full recount)"
     echo -e "\t--job [ID]\n\t\t Run one menu option non-interactively (supports 1-22 and 99)"
     echo -e "\t--list-jobs\n\t\t Print available job IDs and exit"
     echo -e "\t--self-test / --doctor\n\t\t Run non-interactive dependency and configuration checks, then exit"
@@ -62,6 +63,7 @@ while [[ "$#" -gt 0 ]]; do
         -d | --disable-cracked) SHOWCRACKED=' ' ;;
         --dry-run) DRYRUN=' ' ;;
         --no-session-log) SESSION_LOG_DISABLED='1' ;;
+        --stats-debug) STATSDEBUG=' ' ;;
         --job)
             case "${2:-}" in
                 '' | *[!0-9]*)
@@ -278,6 +280,10 @@ else
     else
         status_ok "Session log retention: keeping last $SESSION_LOG_KEEP_EFFECTIVE file(s)"
     fi
+fi
+
+if [ "$STATSDEBUG" = ' ' ]; then
+    status_ok "Stats debug output enabled"
 fi
 
 if [ "$JOBLIST" = ' ' ]; then

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -88,6 +88,9 @@ fi
 if ! grep -Fq '"generated_at"' "$STATS_EXPORT_PATH"; then
     fail_with_log "stats export missing generated_at key" "$STATS_EXPORT_PATH"
 fi
+if ! grep -Fq '"schema_version": "1"' "$STATS_EXPORT_PATH"; then
+    fail_with_log "stats export missing schema_version" "$STATS_EXPORT_PATH"
+fi
 if ! grep -Fq '"session"' "$STATS_EXPORT_PATH"; then
     fail_with_log "stats export missing session object" "$STATS_EXPORT_PATH"
 fi

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -77,6 +77,27 @@ assert_contains "0. Exit"
 assert_contains "99. Session stats dashboard"
 assert_contains "Bye..."
 
+echo "[smoke] list-jobs mode prints options and exits"
+run_case list_jobs bash -lc "./hash-cracker.sh --dry-run --list-jobs"
+assert_rc_eq 0
+assert_contains "1. Brute force"
+assert_contains "99. Session stats dashboard"
+
+echo "[smoke] non-interactive --job mode runs a job and exits"
+run_case single_job bash -lc "./hash-cracker.sh --dry-run --job 1"
+assert_rc_eq 0
+assert_contains "Brute force processing done"
+
+echo "[smoke] invalid --job selection fails clearly"
+run_case single_job_invalid bash -lc "./hash-cracker.sh --dry-run --job 999"
+assert_rc_eq 1
+assert_contains "Invalid job selection for --job: 999"
+
+echo "[smoke] prompting --job in non-interactive mode fails clearly"
+run_case single_job_prompting bash -lc "./hash-cracker.sh --dry-run --job 8"
+assert_rc_eq 1
+assert_contains "requires interactive input and cannot run in non-interactive --job mode"
+
 echo "[smoke] invalid option recovers back to menu"
 run_case invalid_option bash -lc "printf '999\n0\n' | ./hash-cracker.sh --dry-run"
 assert_rc_eq 0

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -69,6 +69,13 @@ echo "[smoke] help output includes self-test flag"
 run_case help bash -lc "./hash-cracker.sh --help"
 assert_rc_eq 1
 assert_contains "--self-test / --doctor"
+assert_contains "--stats-debug"
+
+echo "[smoke] stats debug flag is accepted"
+run_case stats_debug bash -lc "printf '0\n' | ./hash-cracker.sh --dry-run --stats-debug"
+assert_rc_eq 0
+assert_contains "Stats debug output enabled"
+assert_contains "Bye..."
 
 echo "[smoke] dry-run menu exits cleanly"
 run_case menu_exit bash -lc "printf '0\n' | ./hash-cracker.sh --dry-run"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -70,12 +70,49 @@ run_case help bash -lc "./hash-cracker.sh --help"
 assert_rc_eq 1
 assert_contains "--self-test / --doctor"
 assert_contains "--stats-debug"
+assert_contains "--stats-export-scope [latest|all]"
 
 echo "[smoke] stats debug flag is accepted"
 run_case stats_debug bash -lc "printf '0\n' | ./hash-cracker.sh --dry-run --stats-debug"
 assert_rc_eq 0
 assert_contains "Stats debug output enabled"
 assert_contains "Bye..."
+
+echo "[smoke] stats export writes JSON file"
+STATS_EXPORT_PATH="$TMP_DIR/stats-export.json"
+run_case stats_export bash -lc "printf '0\n' | ./hash-cracker.sh --dry-run --stats-export \"$STATS_EXPORT_PATH\""
+assert_rc_eq 0
+if [ ! -s "$STATS_EXPORT_PATH" ]; then
+    fail_with_log "stats export file was not created" "$LAST_LOG"
+fi
+if ! grep -Fq '"generated_at"' "$STATS_EXPORT_PATH"; then
+    fail_with_log "stats export missing generated_at key" "$STATS_EXPORT_PATH"
+fi
+if ! grep -Fq '"session"' "$STATS_EXPORT_PATH"; then
+    fail_with_log "stats export missing session object" "$STATS_EXPORT_PATH"
+fi
+if ! grep -Fq '"potfile_totals"' "$STATS_EXPORT_PATH"; then
+    fail_with_log "stats export missing potfile_totals object" "$STATS_EXPORT_PATH"
+fi
+
+echo "[smoke] stats export scope all includes history entries"
+STATS_EXPORT_ALL_PATH="$TMP_DIR/stats-export-all.json"
+run_case stats_export_all bash -lc "printf '0\n' | ./hash-cracker.sh --dry-run --stats-export \"$STATS_EXPORT_ALL_PATH\" --stats-export-scope all"
+assert_rc_eq 0
+if ! grep -Fq '"export_scope": "all"' "$STATS_EXPORT_ALL_PATH"; then
+    fail_with_log "stats export scope all missing export_scope marker" "$STATS_EXPORT_ALL_PATH"
+fi
+if ! grep -Fq '"history": [' "$STATS_EXPORT_ALL_PATH"; then
+    fail_with_log "stats export scope all missing history array" "$STATS_EXPORT_ALL_PATH"
+fi
+if ! grep -Fq '"message": "Session stats:' "$STATS_EXPORT_ALL_PATH"; then
+    fail_with_log "stats export scope all missing parsed session stats message entries" "$STATS_EXPORT_ALL_PATH"
+fi
+
+echo "[smoke] invalid stats export scope fails clearly"
+run_case stats_export_scope_invalid bash -lc "./hash-cracker.sh --stats-export \"$TMP_DIR/invalid-scope.json\" --stats-export-scope nope"
+assert_rc_eq 1
+assert_contains "Invalid value for --stats-export-scope. Use 'latest' or 'all'."
 
 echo "[smoke] dry-run menu exits cleanly"
 run_case menu_exit bash -lc "printf '0\n' | ./hash-cracker.sh --dry-run"


### PR DESCRIPTION
## v6.0 - Command Forge

### Highlights

- Added first-class non-interactive execution for automation workflows.

### Added

- New flag: `--list-jobs`
  - Prints available job IDs and descriptions, then exits.
- New flag: `--job [ID]` (also supports `--job=ID`)
  - Runs a single option non-interactively and exits.
  - Supports all menu jobs `1-22` and dashboard `99`.
- New flag: `--stats-debug`
  - Prints whether session stats refresh used incremental update or full recount.
- New flag: `--stats-export [PATH]` (also supports `--stats-export=PATH`)
  - Exports machine-readable session stats as JSON on each refresh cycle.
- New flag: `--stats-export-scope [latest|all]` (also supports `--stats-export-scope=...`)
  - `latest` (default): exports only the current snapshot JSON.
  - `all`: includes parsed history entries from `logs/session-*.log` in JSON output.

### Changed

- Startup and dashboard release label updated to `v6.0 "Command Forge"`.
- Non-interactive job runs now reuse existing dependency validation and session-stats logging behavior.
- Prompt-dependent jobs now fail fast in non-interactive `--job` mode with clear guidance.
- Session stats unique-count refresh now uses incremental cache updates on append growth, with automatic full-recount fallback on non-append changes.
- Stats export JSON now includes top-level `"schema_version": "1"` for downstream compatibility checks.