### PR TITLE
v6.3 "Preset Rail"

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ Run one job non-interactively:
 ./hash-cracker.sh --job 8
 ```
 
+List built-in presets:
+
+```bash
+./hash-cracker.sh --list-presets
+```
+
+Run a built-in preset:
+
+```bash
+./hash-cracker.sh --preset quick
+```
+
 Run with session logging disabled:
 
 ```bash
@@ -189,7 +201,18 @@ By default, `hash-cracker` enables optimized kernels, enables loopback, disables
 - `--stats-export-scope [latest|all]`, `--stats-export-scope=...` - export latest snapshot only (`latest`, default) or include all parsed entries from `logs/session-*.log` (`all`)
 - `--job [ID]`, `--job=ID` - run one menu option non-interactively and exit (supports `1-22` and `99`)
 - `--list-jobs` - print available job IDs and exit
+- `--preset [NAME]`, `--preset=NAME` - run a built-in non-interactive job preset and exit
+- `--list-presets` - print available built-in presets and exit
 - `--self-test`, `--doctor` - run non-interactive configuration and dependency checks, then exit with status code
+
+## Built-In Presets
+
+Presets run safe non-interactive jobs in sequence and stop on the first failed job.
+
+- `quick` - baseline and iteration coverage (`1,9`)
+- `quick-plus` - quick coverage plus common substring pass (`1,9,11`)
+- `deep` - baseline, iteration, prefix/suffix, substring, and digit-remover coverage (`1,9,10,11,19`)
+- `deep-plus` - extended potfile-driven coverage with prefix/suffix and substring passes (`1,9,10,11,14,19,9`)
 
 ## Menu Options
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,24 @@
 # Version log
 
+## v6.3 - Preset Rail
+
+### Added
+
+- New flag: `--list-presets`
+  - Prints available built-in preset names, descriptions, and job sequences.
+- New flag: `--preset [NAME]` (also supports `--preset=NAME`)
+  - Runs a built-in non-interactive job preset and exits.
+- Built-in presets:
+  - `quick`: baseline and iteration coverage with jobs `1,9`.
+  - `quick-plus`: quick coverage plus common substring pass with jobs `1,9,11`.
+  - `deep`: baseline, iteration, prefix/suffix, substring, and digit-remover coverage with jobs `1,9,10,11,19`.
+  - `deep-plus`: extended potfile-driven coverage with jobs `1,9,10,11,14,19,9`.
+
+### Changed
+
+- Runtime release label/banner now reports `v6.3 "Preset Rail"`.
+- Preset runs stop on the first failed job and report the preset name, job ID, and job label.
+
 ## v6.2 - Long Reach
 
 ### Changed

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -50,7 +50,7 @@ function banner_center_line() {
 }
 
 function release_version_text() {
-    printf '%s' 'v6.2 "Long Reach"'
+    printf '%s' 'v6.3 "Preset Rail"'
 }
 
 function release_label_text() {
@@ -120,6 +120,75 @@ function print_job_list() {
         echo "$option_id. $option_text"
     done < <(menu_entries)
     echo "99. Session stats dashboard"
+}
+
+function preset_entries() {
+    cat <<'EOF'
+quick|Quick baseline and iteration coverage|1,9
+quick-plus|Quick coverage plus common substring pass|1,9,11
+deep|Baseline, iteration, prefix/suffix, substring, and digit-remover coverage|1,9,10,11,19
+deep-plus|Extended potfile-driven coverage with prefix/suffix and substring passes|1,9,10,11,14,19,9
+EOF
+}
+
+function print_preset_list() {
+    local preset_name preset_text preset_jobs
+
+    while IFS='|' read -r preset_name preset_text preset_jobs; do
+        printf '%s - %s (jobs: %s)\n' "$preset_name" "$preset_text" "$preset_jobs"
+    done < <(preset_entries)
+}
+
+function run_early_list_mode() {
+    local arg
+
+    for arg in "$@"; do
+        case "$arg" in
+            --list-jobs)
+                print_job_list
+                exit 0
+                ;;
+            --list-presets)
+                print_preset_list
+                exit 0
+                ;;
+        esac
+    done
+}
+
+function get_preset_jobs() {
+    local selected="$1"
+    local preset_name preset_text preset_jobs
+
+    while IFS='|' read -r preset_name preset_text preset_jobs; do
+        if [[ "$selected" == "$preset_name" ]]; then
+            printf '%s' "$preset_jobs"
+            return 0
+        fi
+    done < <(preset_entries)
+
+    return 1
+}
+
+function job_text_by_id() {
+    local selected="$1"
+    local option_id option_text processor
+
+    while IFS='|' read -r option_id option_text processor; do
+        if [[ "$selected" == "$option_id" ]]; then
+            printf '%s' "$option_text"
+            return 0
+        fi
+    done < <(menu_entries)
+
+    return 1
+}
+
+function preset_job_supported() {
+    case "$1" in
+        1 | 9 | 10 | 11 | 12 | 13 | 14 | 16 | 19) return 0 ;;
+        *) return 1 ;;
+    esac
 }
 
 function dependency_fail() {
@@ -835,6 +904,67 @@ function run_single_job_mode() {
     return $rc
 }
 
+function run_preset_mode() {
+    local preset_name="$1"
+    local preset_jobs
+    local job_id
+    local job_text
+    local rc
+    local session_stats_line
+    local -a preset_job_ids
+
+    if ! preset_jobs="$(get_preset_jobs "$preset_name")"; then
+        status_error "Invalid preset: $preset_name"
+        status_heading "Use --list-presets to see available presets."
+        return 1
+    fi
+
+    IFS=',' read -ra preset_job_ids <<<"$preset_jobs"
+    for job_id in "${preset_job_ids[@]}"; do
+        if ! preset_job_supported "$job_id"; then
+            status_error "Preset '$preset_name' contains unsupported non-interactive job: $job_id"
+            status_heading "Presets currently support jobs 1, 9, 10, 11, 12, 13, 14, 16, and 19."
+            return 1
+        fi
+        if ! job_text="$(job_text_by_id "$job_id")"; then
+            status_error "Preset '$preset_name' contains unknown job: $job_id"
+            status_heading "Use --list-jobs to see available jobs."
+            return 1
+        fi
+    done
+
+    refresh_session_stats
+    session_stats_line=$(build_session_stats_line)
+    log_session_stats_line "$session_stats_line"
+    export_session_stats_json
+
+    status_heading "Running preset '$preset_name' (jobs: $preset_jobs)"
+    for job_id in "${preset_job_ids[@]}"; do
+        job_text="$(job_text_by_id "$job_id")"
+        status_heading "Preset '$preset_name': running job $job_id ($job_text)"
+
+        if ! check_job_dependencies "$job_id"; then
+            status_error "Preset '$preset_name' failed before job $job_id ($job_text): missing dependency."
+            return 1
+        fi
+
+        run_processor "$job_id"
+        rc=$?
+        if [ "$rc" -ne 0 ]; then
+            status_error "Preset '$preset_name' failed at job $job_id ($job_text)."
+            return "$rc"
+        fi
+
+        refresh_session_stats
+        session_stats_line=$(build_session_stats_line)
+        log_session_stats_line "$session_stats_line"
+        export_session_stats_json
+    done
+
+    status_ok "Preset '$preset_name' completed."
+    return 0
+}
+
 function menu() {
     local option_id option_text processor
     local session_stats_line
@@ -885,6 +1015,7 @@ function menu() {
     done
 }
 
+run_early_list_mode "$@"
 init_colors
 trap cleanup_session_state EXIT
 source scripts/parameters.sh "$@"
@@ -896,8 +1027,23 @@ if [ "$JOBLIST" = ' ' ]; then
     exit 0
 fi
 
+if [ "$PRESETLIST" = ' ' ]; then
+    print_preset_list
+    exit 0
+fi
+
 if [ "$SELFTEST" = ' ' ]; then
     run_self_test
+    exit $?
+fi
+
+if [ -n "${PRESETMODE:-}" ] && [ -n "${JOBMODE:-}" ]; then
+    status_error "Use either --preset or --job, not both."
+    exit 1
+fi
+
+if [ -n "${PRESETMODE:-}" ]; then
+    run_preset_mode "$PRESETMODE"
     exit $?
 fi
 

--- a/scripts/parameters.sh
+++ b/scripts/parameters.sh
@@ -19,6 +19,8 @@ if [ "$1" == '-h' ] || [ "$1" == '--help' ]; then
     echo -e "\t--stats-export-scope [latest|all]\n\t\t Export latest snapshot only or all entries from logs (default: latest)"
     echo -e "\t--job [ID]\n\t\t Run one menu option non-interactively (supports 1-22 and 99)"
     echo -e "\t--list-jobs\n\t\t Print available job IDs and exit"
+    echo -e "\t--preset [NAME]\n\t\t Run a built-in non-interactive job preset"
+    echo -e "\t--list-presets\n\t\t Print available preset names and exit"
     echo -e "\t--self-test / --doctor\n\t\t Run non-interactive dependency and configuration checks, then exit"
     exit 1
 elif [ "$1" == '-m' ] || [ "$1" == '--module-info' ]; then
@@ -125,6 +127,22 @@ while [[ "$#" -gt 0 ]]; do
             esac
             ;;
         --list-jobs) JOBLIST=' ' ;;
+        --preset)
+            if [ -z "${2:-}" ]; then
+                status_error "Missing value for --preset. Provide a preset name."
+                exit 1
+            fi
+            PRESETMODE="$2"
+            shift
+            ;;
+        --preset=*)
+            PRESETMODE="${1#*=}"
+            if [ -z "$PRESETMODE" ]; then
+                status_error "Missing value for --preset. Provide a preset name."
+                exit 1
+            fi
+            ;;
+        --list-presets) PRESETLIST=' ' ;;
         --session-log-keep)
             case "${2:-}" in
                 '' | *[!0-9]*)
@@ -330,12 +348,12 @@ if [ -n "${STATSEXPORT:-}" ]; then
     status_ok "Stats export scope: ${STATSEXPORT_SCOPE:-latest}"
 fi
 
-if [ "$JOBLIST" = ' ' ]; then
-    status_ok "Job listing mode enabled"
-fi
-
 if [ -n "${JOBMODE:-}" ]; then
     status_ok "Non-interactive job mode enabled: job $JOBMODE"
+fi
+
+if [ -n "${PRESETMODE:-}" ]; then
+    status_ok "Preset mode enabled: $PRESETMODE"
 fi
 
 echo -e "\nStatic parameters:"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -57,6 +57,15 @@ assert_contains() {
     fi
 }
 
+assert_not_contains() {
+    local needle="$1"
+    if grep -Fq -- "$needle" "$LAST_LOG"; then
+        echo "[FAIL] expected output not to contain: $needle"
+        cat "$LAST_LOG"
+        exit 1
+    fi
+}
+
 fail_with_log() {
     local message="$1"
     local log_file="$2"
@@ -71,6 +80,8 @@ assert_rc_eq 1
 assert_contains "--self-test / --doctor"
 assert_contains "--stats-debug"
 assert_contains "--stats-export-scope [latest|all]"
+assert_contains "--preset [NAME]"
+assert_contains "--list-presets"
 
 echo "[smoke] stats debug flag is accepted"
 run_case stats_debug bash -lc "printf '0\n' | ./hash-cracker.sh --dry-run --stats-debug"
@@ -130,15 +141,82 @@ assert_rc_eq 0
 assert_contains "1. Brute force"
 assert_contains "99. Session stats dashboard"
 
+echo "[smoke] list-presets mode prints built-in presets and exits"
+run_case list_presets bash -lc "./hash-cracker.sh --dry-run --list-presets"
+assert_rc_eq 0
+assert_contains "quick - Quick baseline and iteration coverage (jobs: 1,9)"
+assert_contains "quick-plus - Quick coverage plus common substring pass (jobs: 1,9,11)"
+assert_contains "deep - Baseline, iteration, prefix/suffix, substring, and digit-remover coverage (jobs: 1,9,10,11,19)"
+assert_contains "deep-plus - Extended potfile-driven coverage with prefix/suffix and substring passes (jobs: 1,9,10,11,14,19,9)"
+assert_not_contains "Mandatory modules:"
+assert_not_contains "Preparing session stats"
+assert_not_contains "Static parameters:"
+
 echo "[smoke] non-interactive --job mode runs a job and exits"
 run_case single_job bash -lc "./hash-cracker.sh --dry-run --job 1"
 assert_rc_eq 0
 assert_contains "Brute force processing done"
 
+echo "[smoke] preset quick runs and exits"
+run_case preset_quick bash -lc "./hash-cracker.sh --dry-run --preset quick"
+assert_rc_eq 0
+assert_contains "Running preset 'quick' (jobs: 1,9)"
+assert_contains "Preset 'quick': running job 1 (Brute force)"
+assert_contains "Preset 'quick': running job 9 (Iterate results)"
+assert_contains "Brute force processing done"
+assert_contains "Iteration processing done"
+assert_contains "Preset 'quick' completed."
+
+echo "[smoke] preset deep-plus dry-run reaches extended jobs"
+FAKE_COMMON_SUBSTR="$TMP_DIR/fake-common-substr.sh"
+cat >"$FAKE_COMMON_SUBSTR" <<EOF
+#!/usr/bin/env bash
+cat >/dev/null
+printf 'preview\n'
+EOF
+chmod +x "$FAKE_COMMON_SUBSTR"
+
+echo "[smoke] preset quick-plus dry-run reaches common substring job"
+run_case preset_quick_plus bash -lc "COMMON_SUBSTR_BIN=\"$FAKE_COMMON_SUBSTR\" ./hash-cracker.sh --dry-run --preset quick-plus"
+assert_rc_eq 0
+assert_contains "Running preset 'quick-plus' (jobs: 1,9,11)"
+assert_contains "Preset 'quick-plus': running job 11 (Common substring (advise: first run steps above))"
+assert_contains "Preset 'quick-plus' completed."
+
+run_case preset_deep_plus bash -lc "COMMON_SUBSTR_BIN=\"$FAKE_COMMON_SUBSTR\" ./hash-cracker.sh --dry-run --preset deep-plus"
+assert_rc_eq 0
+assert_contains "Running preset 'deep-plus' (jobs: 1,9,10,11,14,19,9)"
+assert_contains "Preset 'deep-plus': running job 10 (Prefix suffix (advise: first run steps above))"
+assert_contains "Preset 'deep-plus': running job 11 (Common substring (advise: first run steps above))"
+assert_contains "Preset 'deep-plus' completed."
+
+echo "[smoke] invalid preset selection fails clearly"
+run_case preset_invalid bash -lc "./hash-cracker.sh --dry-run --preset nope"
+assert_rc_eq 1
+assert_contains "Invalid preset: nope"
+assert_contains "Use --list-presets to see available presets."
+
+echo "[smoke] preset mode exports stats"
+PRESET_STATS_EXPORT_PATH="$TMP_DIR/preset-stats-export.json"
+run_case preset_stats_export bash -lc "./hash-cracker.sh --dry-run --preset quick --stats-export \"$PRESET_STATS_EXPORT_PATH\""
+assert_rc_eq 0
+assert_contains "Preset 'quick' completed."
+if [ ! -s "$PRESET_STATS_EXPORT_PATH" ]; then
+    fail_with_log "preset stats export file was not created" "$LAST_LOG"
+fi
+if ! grep -Fq '"release": "v6.3 \"Preset Rail\""' "$PRESET_STATS_EXPORT_PATH"; then
+    fail_with_log "preset stats export missing v6.3 release marker" "$PRESET_STATS_EXPORT_PATH"
+fi
+
 echo "[smoke] invalid --job selection fails clearly"
 run_case single_job_invalid bash -lc "./hash-cracker.sh --dry-run --job 999"
 assert_rc_eq 1
 assert_contains "Invalid job selection for --job: 999"
+
+echo "[smoke] preset and job modes are mutually exclusive"
+run_case preset_job_conflict bash -lc "./hash-cracker.sh --dry-run --preset quick --job 1"
+assert_rc_eq 1
+assert_contains "Use either --preset or --job, not both."
 
 echo "[smoke] prompting --job in non-interactive mode fails clearly"
 run_case single_job_prompting bash -lc "./hash-cracker.sh --dry-run --job 8"


### PR DESCRIPTION
### Added

- New flag: `--list-presets`
  - Prints available built-in preset names, descriptions, and job sequences.
- New flag: `--preset [NAME]` (also supports `--preset=NAME`)
  - Runs a built-in non-interactive job preset and exits.
- Built-in presets:
  - `quick`: baseline and iteration coverage with jobs `1,9`.
  - `quick-plus`: quick coverage plus common substring pass with jobs `1,9,11`.
  - `deep`: baseline, iteration, prefix/suffix, substring, and digit-remover coverage with jobs `1,9,10,11,19`.
  - `deep-plus`: extended potfile-driven coverage with jobs `1,9,10,11,14,19,9`.

### Changed

- Runtime release label/banner now reports `v6.3 "Preset Rail"`.
- Preset runs stop on the first failed job and report the preset name, job ID, and job label.