### PR TITLE
v6.4.1 "Run Ledger"

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,11 @@
 # Version log
 
+## v6.4.1 - Run Ledger
+
+### Fixed
+
+- Session stats incremental refresh now runs `comm` with `LC_ALL=C`, matching the sorted plaintext cache collation and preventing false "input is not in sorted order" warnings after jobs add potfile entries.
+
 ## v6.4 - Run Ledger
 
 ### Added

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -50,7 +50,7 @@ function banner_center_line() {
 }
 
 function release_version_text() {
-    printf '%s' 'v6.4 "Run Ledger"'
+    printf '%s' 'v6.4.1 "Run Ledger"'
 }
 
 function release_label_text() {
@@ -485,7 +485,7 @@ function update_unique_plaintexts_incremental() {
         : >"$SESSION_POT_UNIQUE_CACHE"
     fi
 
-    new_unique_lines=$(comm -13 "$SESSION_POT_UNIQUE_CACHE" "$tmp_delta" | wc -l | tr -d '[:space:]')
+    new_unique_lines=$(LC_ALL=C comm -13 "$SESSION_POT_UNIQUE_CACHE" "$tmp_delta" | wc -l | tr -d '[:space:]')
     if [ "$new_unique_lines" -gt 0 ]; then
         cat "$SESSION_POT_UNIQUE_CACHE" "$tmp_delta" | LC_ALL=C sort -u >"$tmp_merge"
         mv "$tmp_merge" "$SESSION_POT_UNIQUE_CACHE"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -210,8 +210,8 @@ assert_contains "Preset 'quick' completed."
 if [ ! -s "$PRESET_STATS_EXPORT_PATH" ]; then
     fail_with_log "preset stats export file was not created" "$LAST_LOG"
 fi
-if ! grep -Fq '"release": "v6.4 \"Run Ledger\""' "$PRESET_STATS_EXPORT_PATH"; then
-    fail_with_log "preset stats export missing v6.4 release marker" "$PRESET_STATS_EXPORT_PATH"
+if ! grep -Fq '"release": "v6.4.1 \"Run Ledger\""' "$PRESET_STATS_EXPORT_PATH"; then
+    fail_with_log "preset stats export missing v6.4.1 release marker" "$PRESET_STATS_EXPORT_PATH"
 fi
 
 echo "[smoke] invalid --job selection fails clearly"


### PR DESCRIPTION
- Session stats incremental refresh now runs `comm` with `LC_ALL=C`, matching the sorted plaintext cache collation and preventing false "input is not in sorted order" warnings after jobs add potfile entries.