### PR TITLE
Add reproducible campaign manifests

### DIFF
--- a/.github/workflows/shell-quality.yml
+++ b/.github/workflows/shell-quality.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install lint/format tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck shfmt
+          sudo apt-get install -y python3 shellcheck shfmt
 
       - name: Run shell lint
         run: make lint
@@ -27,6 +27,8 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    env:
+      COVERAGE_TMP_ROOT: /var/tmp
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ Run non-interactive health checks:
 ./hash-cracker.sh --self-test
 ```
 
+Create and run a reproducible campaign plan (requires `python3`):
+
+```bash
+./hash-cracker.sh --plan deep-plus --output campaign.json
+./hash-cracker.sh --execute campaign.json
+./hash-cracker.sh --resume campaign.json
+```
+
+Campaign manifests record the ordered jobs, resolved Hashcat commands, immutable input fingerprints, per-step exit codes, and execution state. Plans never execute Hashcat. Execution resumes the first incomplete step and rejects changed configuration, runtime flags, hashlist, or wordlist inputs; the potfile is treated as mutable campaign state. Campaign sources are built-in presets or non-interactive job IDs: `1`, `9`, `10`, `11`, `12`, `13`, `14`, `16`, and `19`.
+
 Run the smoke suite with Bash coverage (requires `python3`):
 
 ```bash
@@ -213,6 +223,9 @@ By default, `hash-cracker` enables optimized kernels, enables loopback, disables
 - `--list-jobs` - print available job IDs and exit
 - `--preset [NAME]`, `--preset=NAME` - run a built-in non-interactive job preset and exit
 - `--list-presets` - print available built-in presets and exit
+- `--plan [PRESET|JOB] --output PATH` - create a versioned campaign manifest without executing Hashcat
+- `--execute PATH` - execute a campaign manifest from its first incomplete step
+- `--resume PATH` - resume an interrupted or failed campaign manifest
 - `--self-test`, `--doctor` - run non-interactive configuration and dependency checks, then exit with status code
 
 ## Built-In Presets

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,11 @@
 # Version log
 
+## Unreleased
+
+### Added
+
+- Added reproducible campaign manifests with command previews, input fingerprints, atomic step state, execution, and resume support.
+
 ## v6.5.0 - Coverage Gate
 
 ### Added

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -184,6 +184,20 @@ function job_text_by_id() {
     return 1
 }
 
+function processor_path_by_id() {
+    local selected="$1"
+    local option_id option_text processor
+
+    while IFS='|' read -r option_id option_text processor; do
+        if [[ "$selected" == "$option_id" ]]; then
+            printf '%s' "$processor"
+            return 0
+        fi
+    done < <(menu_entries)
+
+    return 1
+}
+
 function current_epoch_seconds() {
     date '+%s'
 }
@@ -368,7 +382,229 @@ function run_processor() {
         fi
     )
     rc=$?
+    if [ -n "${CAMPAIGN_INTERRUPT_MARKER:-}" ] && [ -f "$CAMPAIGN_INTERRUPT_MARKER" ]; then
+        return 130
+    fi
     return "$rc"
+}
+
+function campaign_record_command() {
+    local command_line="$1"
+    printf '%s\t%s\n' "$CAMPAIGN_CURRENT_STEP" "$command_line" >>"$CAMPAIGN_COMMAND_FILE"
+}
+
+function campaign_jobs_for_source() {
+    local source="$1"
+
+    if [[ "$source" =~ ^[0-9]+$ ]]; then
+        if ! preset_job_supported "$source"; then
+            status_error "Campaign job '$source' requires interactive input or is unsupported." >&2
+            status_heading "Campaigns support non-interactive jobs 1, 9, 10, 11, 12, 13, 14, 16, and 19." >&2
+            return 1
+        fi
+        printf '%s' "$source"
+        return 0
+    fi
+
+    if ! get_preset_jobs "$source"; then
+        status_error "Invalid campaign preset: $source" >&2
+        status_heading "Use --list-presets to see available campaign sources." >&2
+        return 1
+    fi
+}
+
+function run_campaign_plan() {
+    local source="$1"
+    local output="$2"
+    local jobs
+    local step_file
+    local command_file
+    local job_id
+    local job_text
+    local processor
+    local step_id
+    local index=1
+    local rc
+    local kind='preset'
+    local -a job_ids
+
+    if [[ "$source" =~ ^[0-9]+$ ]]; then
+        kind='job'
+    fi
+    if ! jobs="$(campaign_jobs_for_source "$source")"; then
+        return 1
+    fi
+
+    step_file=$(mktemp /tmp/hash-cracker-campaign-steps.XXXX)
+    command_file=$(mktemp /tmp/hash-cracker-campaign-commands.XXXX)
+    : >"$command_file"
+    CAMPAIGN_MODE='plan'
+    CAMPAIGN_COMMAND_FILE="$command_file"
+    status_heading "Planning campaign '$source' (jobs: $jobs)"
+
+    IFS=',' read -ra job_ids <<<"$jobs"
+    for job_id in "${job_ids[@]}"; do
+        if ! job_text="$(job_text_by_id "$job_id")" || ! processor="$(processor_path_by_id "$job_id")"; then
+            status_error "Campaign source '$source' contains unknown job: $job_id"
+            rm -f -- "$step_file" "$command_file"
+            return 1
+        fi
+
+        step_id=$(printf 'step-%03d-job-%s' "$index" "$job_id")
+        printf '%s\t%s\t%s\t%s\n' "$step_id" "$job_id" "$job_text" "$processor" >>"$step_file"
+        CAMPAIGN_CURRENT_STEP="$step_id"
+        if ! check_job_dependencies "$job_id"; then
+            status_error "Campaign '$source' cannot plan job $job_id ($job_text)."
+            rm -f -- "$step_file" "$command_file"
+            return 1
+        fi
+        run_processor "$job_id"
+        rc=$?
+        if [ "$rc" -ne 0 ]; then
+            status_error "Campaign '$source' failed to plan job $job_id ($job_text)."
+            rm -f -- "$step_file" "$command_file"
+            return "$rc"
+        fi
+        index=$((index + 1))
+    done
+
+    python3 scripts/campaign.py create \
+        --output "$output" \
+        --name "$source" \
+        --kind "$kind" \
+        --release "$(release_version_text)" \
+        --steps-file "$step_file" \
+        --commands-file "$command_file" \
+        --config "$CONFIGFILE" \
+        --hashlist "$HASHLIST" \
+        --potfile "$POTFILE" \
+        --wordlist "$WORDLIST" \
+        --wordlist2 "$WORDLIST2" \
+        --hashcat "$HASHCAT_BIN" \
+        --hashtype "$HASHTYPE" \
+        --machine "$MACHINE" \
+        --kernel="$KERNEL" \
+        --loopback="$LOOPBACK" \
+        --hwmon="$HWMON" \
+        --showcracked="$SHOWCRACKED"
+    rc=$?
+    rm -f -- "$step_file" "$command_file"
+    if [ "$rc" -eq 0 ]; then
+        status_ok "Campaign plan ready: $output"
+    fi
+    return "$rc"
+}
+
+function run_campaign_execute() {
+    local manifest="$1"
+    local action="$2"
+    local next_line
+    local next_rc
+    local index
+    local step_id
+    local job_id
+    local job_text
+    local command_file
+    local interrupt_marker
+    local start_time
+    local duration
+    local rc
+    local state
+    local update_rc
+    local session_stats_line
+
+    if [ ! -f "$manifest" ]; then
+        status_error "Campaign manifest not found: $manifest"
+        return 1
+    fi
+    if ! python3 scripts/campaign.py validate \
+        --manifest "$manifest" \
+        --config "$CONFIGFILE" \
+        --hashlist "$HASHLIST" \
+        --wordlist "$WORDLIST" \
+        --wordlist2 "$WORDLIST2" \
+        --hashcat "$HASHCAT_BIN" \
+        --hashtype "$HASHTYPE" \
+        --machine "$MACHINE" \
+        --kernel="$KERNEL" \
+        --loopback="$LOOPBACK" \
+        --hwmon="$HWMON" \
+        --showcracked="$SHOWCRACKED"; then
+        return 1
+    fi
+
+    status_heading "${action^} campaign: $manifest"
+    while true; do
+        next_line="$(python3 scripts/campaign.py next --manifest "$manifest")"
+        next_rc=$?
+        if [ "$next_rc" -eq 2 ]; then
+            status_ok "Campaign has no incomplete steps: $manifest"
+            return 0
+        fi
+        if [ "$next_rc" -ne 0 ]; then
+            status_error "Unable to read the next campaign step."
+            return "$next_rc"
+        fi
+
+        IFS='|' read -r index step_id job_id job_text <<<"$next_line"
+        status_heading "Campaign step $step_id: job $job_id ($job_text)"
+        if ! python3 scripts/campaign.py mark-running \
+            --manifest "$manifest" \
+            --index "$index" \
+            --step-id "$step_id"; then
+            return 1
+        fi
+
+        command_file=$(mktemp /tmp/hash-cracker-campaign-executed.XXXX)
+        interrupt_marker="${command_file}.interrupt"
+        : >"$command_file"
+        rm -f -- "$interrupt_marker"
+        # shellcheck disable=SC2034
+        CAMPAIGN_MODE='execute'
+        CAMPAIGN_CURRENT_STEP="$step_id"
+        CAMPAIGN_COMMAND_FILE="$command_file"
+        CAMPAIGN_INTERRUPT_MARKER="$interrupt_marker"
+        start_time=$(current_epoch_seconds)
+
+        if ! check_job_dependencies "$job_id"; then
+            rc=1
+        else
+            run_processor "$job_id"
+            rc=$?
+        fi
+        duration=$(($(current_epoch_seconds) - start_time))
+        if [ "$rc" -eq 0 ]; then
+            state='completed'
+        elif [ "$rc" -eq 130 ]; then
+            state='interrupted'
+        else
+            state='failed'
+        fi
+
+        python3 scripts/campaign.py update \
+            --manifest "$manifest" \
+            --index "$index" \
+            --step-id "$step_id" \
+            --state "$state" \
+            --exit-code "$rc" \
+            --duration "$duration" \
+            --commands-file "$command_file"
+        update_rc=$?
+        rm -f -- "$command_file" "$interrupt_marker"
+        if [ "$update_rc" -ne 0 ]; then
+            return "$update_rc"
+        fi
+
+        refresh_session_stats
+        session_stats_line=$(build_session_stats_line)
+        log_session_stats_line "$session_stats_line"
+        export_session_stats_json
+
+        if [ "$rc" -ne 0 ]; then
+            status_error "Campaign '$manifest' stopped at $step_id with rc=$rc."
+            return "$rc"
+        fi
+    done
 }
 
 function hashcat_base() {
@@ -396,6 +632,9 @@ function processor_cleanup() {
 }
 
 function processor_interrupt() {
+    if [ -n "${CAMPAIGN_INTERRUPT_MARKER:-}" ]; then
+        : >"$CAMPAIGN_INTERRUPT_MARKER"
+    fi
     processor_cleanup "$@"
     exit 0
 }
@@ -1147,8 +1386,23 @@ run_early_list_mode "$@"
 init_colors
 trap cleanup_session_state EXIT
 source scripts/parameters.sh "$@"
+
+if [ -n "$CAMPAIGN_PLAN" ]; then
+    run_campaign_plan "$CAMPAIGN_PLAN" "$CAMPAIGN_OUTPUT"
+    exit $?
+fi
+
 status_heading "Preparing session stats (counting potfile and input hashes)..."
 init_session_stats
+
+if [ -n "$CAMPAIGN_EXECUTE" ] || [ -n "$CAMPAIGN_RESUME" ]; then
+    if [ -n "$CAMPAIGN_RESUME" ]; then
+        run_campaign_execute "$CAMPAIGN_RESUME" 'Resuming'
+    else
+        run_campaign_execute "$CAMPAIGN_EXECUTE" 'Executing'
+    fi
+    exit $?
+fi
 
 if [ "$JOBLIST" = ' ' ]; then
     print_job_list

--- a/scripts/campaign.py
+++ b/scripts/campaign.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Create and update reproducible hash-cracker campaign manifests."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import shlex
+import sys
+import tempfile
+from pathlib import Path
+
+
+SCHEMA_VERSION = "1"
+
+
+class CampaignError(Exception):
+    """An expected campaign validation or state error."""
+
+
+def timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def resolved_path(value: str) -> str:
+    return str(Path(value).expanduser().resolve(strict=False))
+
+
+def file_fingerprint(value: str) -> str:
+    path = Path(value)
+    if not path.is_file():
+        return "missing"
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_manifest(path: str) -> dict:
+    manifest_path = Path(path)
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CampaignError(f"cannot read manifest {path}: {error}") from error
+
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise CampaignError(
+            f"unsupported campaign schema: {manifest.get('schema_version', 'missing')}"
+        )
+    if not isinstance(manifest.get("steps"), list) or not manifest["steps"]:
+        raise CampaignError("campaign manifest has no steps")
+    return manifest
+
+
+def write_manifest(path: str, manifest: dict) -> None:
+    destination = Path(path).expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    manifest["updated_at"] = timestamp()
+
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            temporary_path = Path(stream.name)
+            json.dump(manifest, stream, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, destination)
+    finally:
+        if temporary_path and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def read_steps(path: str) -> list[dict]:
+    steps = []
+    for raw_line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        fields = raw_line.split("\t")
+        if len(fields) != 4:
+            raise CampaignError(f"invalid campaign step record: {raw_line}")
+        step_id, job, name, processor = fields
+        steps.append(
+            {
+                "id": step_id,
+                "job": int(job),
+                "name": name,
+                "processor": processor,
+                "commands": [],
+                "executed_commands": [],
+                "state": "pending",
+                "attempts": 0,
+                "exit_code": None,
+                "started_at": None,
+                "finished_at": None,
+                "duration_seconds": None,
+            }
+        )
+    if not steps:
+        raise CampaignError("campaign plan contains no steps")
+    return steps
+
+
+def read_commands(path: str) -> dict[str, list[dict]]:
+    commands: dict[str, list[dict]] = {}
+    for raw_line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            step_id, preview = raw_line.split("\t", 1)
+        except ValueError as error:
+            raise CampaignError(f"invalid campaign command record: {raw_line}") from error
+        try:
+            argv = shlex.split(preview)
+        except ValueError:
+            argv = [preview]
+        commands.setdefault(step_id, []).append(
+            {"preview": preview, "argv": argv}
+        )
+    return commands
+
+
+def input_metadata(args: argparse.Namespace) -> dict:
+    paths = {
+        "config": args.config,
+        "hashlist": args.hashlist,
+        "wordlist": args.wordlist,
+        "wordlist2": args.wordlist2,
+    }
+    metadata = {
+        name: {"path": resolved_path(path), "sha256": file_fingerprint(path)}
+        for name, path in paths.items()
+    }
+    metadata["potfile"] = {"path": resolved_path(args.potfile), "mutable": True}
+    return metadata
+
+
+def runtime_metadata(args: argparse.Namespace) -> dict:
+    return {
+        "hashcat": args.hashcat,
+        "hashtype": args.hashtype,
+        "machine": args.machine,
+        "kernel": args.kernel,
+        "loopback": args.loopback,
+        "hwmon": args.hwmon,
+        "showcracked": args.showcracked,
+    }
+
+
+def create_manifest(args: argparse.Namespace) -> None:
+    steps = read_steps(args.steps_file)
+    commands = read_commands(args.commands_file)
+    for step in steps:
+        step["commands"] = commands.get(step["id"], [])
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "release": args.release,
+        "created_at": timestamp(),
+        "updated_at": timestamp(),
+        "status": "planned",
+        "campaign": {
+            "name": args.name,
+            "kind": args.kind,
+            "jobs": [step["job"] for step in steps],
+        },
+        "inputs": input_metadata(args),
+        "runtime": runtime_metadata(args),
+        "steps": steps,
+    }
+    write_manifest(args.output, manifest)
+    print(f"Campaign plan written to {args.output}")
+    print(f"Campaign: {args.name} | steps: {len(steps)} | status: planned")
+
+
+def validate_manifest(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    current_paths = {
+        "config": args.config,
+        "hashlist": args.hashlist,
+        "wordlist": args.wordlist,
+        "wordlist2": args.wordlist2,
+    }
+    for name, current_path in current_paths.items():
+        expected = manifest["inputs"].get(name, {})
+        current_resolved = resolved_path(current_path)
+        if expected.get("path") != current_resolved:
+            raise CampaignError(
+                f"campaign input path changed for {name}: "
+                f"expected {expected.get('path')}, got {current_resolved}"
+            )
+        current_digest = file_fingerprint(current_path)
+        if expected.get("sha256") != current_digest:
+            raise CampaignError(
+                f"campaign input changed for {name}: {current_resolved}"
+            )
+    expected_runtime = manifest.get("runtime", {})
+    for name, current_value in runtime_metadata(args).items():
+        if expected_runtime.get(name) != current_value:
+            raise CampaignError(
+                f"campaign runtime changed for {name}: "
+                f"expected {expected_runtime.get(name)!r}, got {current_value!r}"
+            )
+    print(f"Campaign validated: {args.manifest}")
+
+
+def next_step(args: argparse.Namespace) -> int:
+    manifest = load_manifest(args.manifest)
+    for index, step in enumerate(manifest["steps"]):
+        if step.get("state") != "completed":
+            print(f"{index}|{step['id']}|{step['job']}|{step['name']}")
+            return 0
+    return 2
+
+
+def mark_running(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    try:
+        step = manifest["steps"][args.index]
+    except (IndexError, TypeError) as error:
+        raise CampaignError(f"invalid campaign step index: {args.index}") from error
+    if step["id"] != args.step_id:
+        raise CampaignError(
+            f"campaign step mismatch: expected {step['id']}, got {args.step_id}"
+        )
+    step["state"] = "running"
+    step["attempts"] = int(step.get("attempts", 0)) + 1
+    step["started_at"] = timestamp()
+    step["finished_at"] = None
+    step["exit_code"] = None
+    manifest["status"] = "running"
+    write_manifest(args.manifest, manifest)
+
+
+def update_step(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    try:
+        step = manifest["steps"][args.index]
+    except (IndexError, TypeError) as error:
+        raise CampaignError(f"invalid campaign step index: {args.index}") from error
+    if step["id"] != args.step_id:
+        raise CampaignError(
+            f"campaign step mismatch: expected {step['id']}, got {args.step_id}"
+        )
+
+    step["state"] = args.state
+    step["exit_code"] = args.exit_code
+    step["duration_seconds"] = args.duration
+    step["finished_at"] = timestamp()
+    if args.commands_file and Path(args.commands_file).is_file():
+        step["executed_commands"].extend(read_commands(args.commands_file).get(step["id"], []))
+
+    if args.state == "completed":
+        manifest["status"] = (
+            "completed"
+            if all(item.get("state") == "completed" for item in manifest["steps"])
+            else "running"
+        )
+    elif args.state == "interrupted":
+        manifest["status"] = "paused"
+    else:
+        manifest["status"] = "failed"
+    write_manifest(args.manifest, manifest)
+
+
+def parser() -> argparse.ArgumentParser:
+    command_parser = argparse.ArgumentParser(
+        description="Manage hash-cracker campaign manifests."
+    )
+    commands = command_parser.add_subparsers(dest="command", required=True)
+
+    create = commands.add_parser("create")
+    create.add_argument("--output", required=True)
+    create.add_argument("--name", required=True)
+    create.add_argument("--kind", required=True)
+    create.add_argument("--release", required=True)
+    create.add_argument("--steps-file", required=True)
+    create.add_argument("--commands-file", required=True)
+    create.add_argument("--config", required=True)
+    create.add_argument("--hashlist", required=True)
+    create.add_argument("--potfile", required=True)
+    create.add_argument("--wordlist", required=True)
+    create.add_argument("--wordlist2", required=True)
+    create.add_argument("--hashcat", required=True)
+    create.add_argument("--hashtype", required=True)
+    create.add_argument("--machine", required=True)
+    create.add_argument("--kernel", required=True)
+    create.add_argument("--loopback", required=True)
+    create.add_argument("--hwmon", required=True)
+    create.add_argument("--showcracked", required=True)
+    create.set_defaults(handler=create_manifest)
+
+    validate = commands.add_parser("validate")
+    validate.add_argument("--manifest", required=True)
+    validate.add_argument("--config", required=True)
+    validate.add_argument("--hashlist", required=True)
+    validate.add_argument("--wordlist", required=True)
+    validate.add_argument("--wordlist2", required=True)
+    validate.add_argument("--hashcat", required=True)
+    validate.add_argument("--hashtype", required=True)
+    validate.add_argument("--machine", required=True)
+    validate.add_argument("--kernel", required=True)
+    validate.add_argument("--loopback", required=True)
+    validate.add_argument("--hwmon", required=True)
+    validate.add_argument("--showcracked", required=True)
+    validate.set_defaults(handler=validate_manifest)
+
+    next_command = commands.add_parser("next")
+    next_command.add_argument("--manifest", required=True)
+    next_command.set_defaults(handler=next_step)
+
+    running = commands.add_parser("mark-running")
+    running.add_argument("--manifest", required=True)
+    running.add_argument("--index", type=int, required=True)
+    running.add_argument("--step-id", required=True)
+    running.set_defaults(handler=mark_running)
+
+    update = commands.add_parser("update")
+    update.add_argument("--manifest", required=True)
+    update.add_argument("--index", type=int, required=True)
+    update.add_argument("--step-id", required=True)
+    update.add_argument(
+        "--state", choices=("completed", "failed", "interrupted"), required=True
+    )
+    update.add_argument("--exit-code", type=int, required=True)
+    update.add_argument("--duration", type=int, required=True)
+    update.add_argument("--commands-file")
+    update.set_defaults(handler=update_step)
+
+    return command_parser
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        result = args.handler(args)
+    except (CampaignError, OSError, ValueError) as error:
+        print(f"campaign: {error}", file=sys.stderr)
+        return 1
+    return result if isinstance(result, int) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/parameters.sh
+++ b/scripts/parameters.sh
@@ -21,6 +21,9 @@ if [ "$1" == '-h' ] || [ "$1" == '--help' ]; then
     echo -e "\t--list-jobs\n\t\t Print available job IDs and exit"
     echo -e "\t--preset [NAME]\n\t\t Run a built-in non-interactive job preset"
     echo -e "\t--list-presets\n\t\t Print available preset names and exit"
+    echo -e "\t--plan [PRESET|JOB] --output PATH\n\t\t Create a reproducible campaign plan without executing Hashcat"
+    echo -e "\t--execute PATH\n\t\t Execute a campaign manifest from its first incomplete step"
+    echo -e "\t--resume PATH\n\t\t Resume an interrupted or failed campaign manifest"
     echo -e "\t--self-test / --doctor\n\t\t Run non-interactive dependency and configuration checks, then exit"
     exit 1
 elif [ "$1" == '-m' ] || [ "$1" == '--module-info' ]; then
@@ -58,6 +61,10 @@ elif [ "$1" == '-s' ] || [ "$1" == '--search' ]; then
 fi
 
 # Dynamic Parameters
+CAMPAIGN_PLAN=''
+CAMPAIGN_OUTPUT=''
+CAMPAIGN_EXECUTE=''
+CAMPAIGN_RESUME=''
 # shellcheck disable=SC2034
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -143,6 +150,66 @@ while [[ "$#" -gt 0 ]]; do
             fi
             ;;
         --list-presets) PRESETLIST=' ' ;;
+        --plan)
+            if [ -z "${2:-}" ]; then
+                status_error "Missing value for --plan. Provide a preset name or job ID."
+                exit 1
+            fi
+            CAMPAIGN_PLAN="$2"
+            shift
+            ;;
+        --plan=*)
+            CAMPAIGN_PLAN="${1#*=}"
+            if [ -z "$CAMPAIGN_PLAN" ]; then
+                status_error "Missing value for --plan. Provide a preset name or job ID."
+                exit 1
+            fi
+            ;;
+        --output)
+            if [ -z "${2:-}" ]; then
+                status_error "Missing value for --output. Provide a campaign manifest path."
+                exit 1
+            fi
+            CAMPAIGN_OUTPUT="$2"
+            shift
+            ;;
+        --output=*)
+            CAMPAIGN_OUTPUT="${1#*=}"
+            if [ -z "$CAMPAIGN_OUTPUT" ]; then
+                status_error "Missing value for --output. Provide a campaign manifest path."
+                exit 1
+            fi
+            ;;
+        --execute)
+            if [ -z "${2:-}" ]; then
+                status_error "Missing value for --execute. Provide a campaign manifest path."
+                exit 1
+            fi
+            CAMPAIGN_EXECUTE="$2"
+            shift
+            ;;
+        --execute=*)
+            CAMPAIGN_EXECUTE="${1#*=}"
+            if [ -z "$CAMPAIGN_EXECUTE" ]; then
+                status_error "Missing value for --execute. Provide a campaign manifest path."
+                exit 1
+            fi
+            ;;
+        --resume)
+            if [ -z "${2:-}" ]; then
+                status_error "Missing value for --resume. Provide a campaign manifest path."
+                exit 1
+            fi
+            CAMPAIGN_RESUME="$2"
+            shift
+            ;;
+        --resume=*)
+            CAMPAIGN_RESUME="${1#*=}"
+            if [ -z "$CAMPAIGN_RESUME" ]; then
+                status_error "Missing value for --resume. Provide a campaign manifest path."
+                exit 1
+            fi
+            ;;
         --session-log-keep)
             case "${2:-}" in
                 '' | *[!0-9]*)
@@ -173,6 +240,38 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+if [ -n "$CAMPAIGN_PLAN" ] && [ -z "$CAMPAIGN_OUTPUT" ]; then
+    status_error "Campaign plans require --output PATH."
+    exit 1
+fi
+if [ -n "$CAMPAIGN_OUTPUT" ] && [ -z "$CAMPAIGN_PLAN" ]; then
+    status_error "--output is only valid with --plan."
+    exit 1
+fi
+if [ -n "$CAMPAIGN_EXECUTE" ] && [ -n "$CAMPAIGN_RESUME" ]; then
+    status_error "Use either --execute or --resume, not both."
+    exit 1
+fi
+if [ -n "$CAMPAIGN_PLAN" ] && { [ -n "$CAMPAIGN_EXECUTE" ] || [ -n "$CAMPAIGN_RESUME" ]; }; then
+    status_error "Use either --plan or --execute/--resume, not both."
+    exit 1
+fi
+if [ -n "$CAMPAIGN_PLAN" ] && { [ -n "${PRESETMODE:-}" ] || [ -n "${JOBMODE:-}" ]; }; then
+    status_error "Use either --plan or --preset/--job, not both."
+    exit 1
+fi
+if [ -n "$CAMPAIGN_EXECUTE" ] && { [ -n "${PRESETMODE:-}" ] || [ -n "${JOBMODE:-}" ]; }; then
+    status_error "Use either --execute/--resume or --preset/--job, not both."
+    exit 1
+fi
+if [ -n "$CAMPAIGN_RESUME" ] && { [ -n "${PRESETMODE:-}" ] || [ -n "${JOBMODE:-}" ]; }; then
+    status_error "Use either --execute/--resume or --preset/--job, not both."
+    exit 1
+fi
+if [ -n "$CAMPAIGN_PLAN" ]; then
+    DRYRUN=' '
+fi
+
 CONFIGFILE="${HASH_CRACKER_CONFIG:-hash-cracker.conf}"
 # shellcheck disable=SC2034
 STATICCONFIG=true
@@ -202,6 +301,9 @@ run_hashcat() {
     local rc
 
     printf -v cmd_line '%q ' "$HASHCAT_BIN" "$@"
+    if [ -n "${CAMPAIGN_COMMAND_FILE:-}" ]; then
+        campaign_record_command "${cmd_line% }"
+    fi
 
     if [ "$DRYRUN" = ' ' ]; then
         printf '[DRY-RUN] '
@@ -356,6 +458,17 @@ fi
 
 if [ -n "${PRESETMODE:-}" ]; then
     status_ok "Preset mode enabled: $PRESETMODE"
+fi
+
+if [ -n "$CAMPAIGN_PLAN" ]; then
+    status_ok "Campaign planning enabled: $CAMPAIGN_PLAN"
+    status_ok "Campaign output: $CAMPAIGN_OUTPUT"
+fi
+if [ -n "$CAMPAIGN_EXECUTE" ]; then
+    status_ok "Campaign execution enabled: $CAMPAIGN_EXECUTE"
+fi
+if [ -n "$CAMPAIGN_RESUME" ]; then
+    status_ok "Campaign resume enabled: $CAMPAIGN_RESUME"
 fi
 
 echo -e "\nStatic parameters:"

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -13,7 +13,8 @@ fi
 rm -rf -- "$COVERAGE_DIR"
 mkdir -p -- "$COVERAGE_DIR"
 
-TMP_DIR="$(mktemp -d /tmp/hash-cracker-coverage.XXXX)"
+COVERAGE_TMP_ROOT="${COVERAGE_TMP_ROOT:-${TMPDIR:-/tmp}}"
+TMP_DIR="$(mktemp -d "$COVERAGE_TMP_ROOT/hash-cracker-coverage.XXXX")"
 trap 'rm -rf -- "$TMP_DIR"' EXIT
 
 TRACE_FILE="$TMP_DIR/bash-trace.log"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -7,6 +7,7 @@ cd "$REPO_ROOT"
 TMP_DIR="$(mktemp -d /tmp/hash-cracker-smoke.XXXX)"
 CONFIG_PATH="$TMP_DIR/hash-cracker.conf"
 export HASH_CRACKER_CONFIG="$CONFIG_PATH"
+export SESSION_LOG_DIR="$TMP_DIR/logs"
 export COMMON_SUBSTR_BIN="$TMP_DIR/common-substr.sh"
 export CEWL="$TMP_DIR/cewl"
 
@@ -119,6 +120,12 @@ assert_not_contains() {
     fi
 }
 
+echo "[smoke] campaign execution failure controls are explicit"
+CAMPAIGN_MISSING_PATH="$TMP_DIR/missing-campaign.json"
+run_case campaign_missing_manifest bash -lc "./hash-cracker.sh --execute '$CAMPAIGN_MISSING_PATH'"
+assert_rc_eq 1
+assert_contains "Campaign manifest not found: $CAMPAIGN_MISSING_PATH"
+
 fail_with_log() {
     local message="$1"
     local log_file="$2"
@@ -145,6 +152,9 @@ assert_rc_eq 0
 run_case helper_invalid_processor bash -lc 'source ./hash-cracker.sh; if run_processor 999; then exit 1; else exit 0; fi'
 assert_rc_eq 0
 
+run_case helper_invalid_processor_path bash -lc 'source ./hash-cracker.sh; if processor_path_by_id 999; then exit 1; else exit 0; fi'
+assert_rc_eq 0
+
 run_case helper_unsupported_preset bash -lc 'source ./hash-cracker.sh; preset_entries() { printf "invalid|Invalid fixture|2\\n"; }; if run_preset_mode invalid; then exit 1; else exit 0; fi'
 assert_rc_eq 0
 
@@ -161,6 +171,24 @@ assert_rc_eq 0
 if [ -e "$HELPER_INTERRUPT_FILE" ]; then
     fail_with_log "processor interrupt did not clean its temporary file" "$LAST_LOG"
 fi
+
+HELPER_CAMPAIGN_INTERRUPT_PROCESSOR="$TMP_DIR/helper-campaign-interrupt-processor.sh"
+HELPER_CAMPAIGN_INTERRUPT_MARKER="$TMP_DIR/helper-campaign-interrupt.marker"
+printf 'processor_interrupt\n' >"$HELPER_CAMPAIGN_INTERRUPT_PROCESSOR"
+run_case helper_campaign_interrupt bash -lc "source '$REPO_ROOT/hash-cracker.sh'; menu_entries() { printf '1|Interrupt fixture|$HELPER_CAMPAIGN_INTERRUPT_PROCESSOR\\n'; }; CAMPAIGN_INTERRUPT_MARKER='$HELPER_CAMPAIGN_INTERRUPT_MARKER'; if run_processor 1; then exit 1; else test \"\$?\" -eq 130; fi"
+assert_rc_eq 0
+if [ ! -f "$HELPER_CAMPAIGN_INTERRUPT_MARKER" ]; then
+    fail_with_log "campaign interrupt marker was not created" "$LAST_LOG"
+fi
+
+run_case helper_campaign_unknown_job bash -lc "source '$REPO_ROOT/hash-cracker.sh'; campaign_jobs_for_source() { printf '999'; }; if run_campaign_plan fixture '$TMP_DIR/unknown-job.json'; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_campaign_dependency_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; campaign_jobs_for_source() { printf '1'; }; check_job_dependencies() { return 1; }; if run_campaign_plan fixture '$TMP_DIR/dependency-failure.json'; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_campaign_plan_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; campaign_jobs_for_source() { printf '1'; }; check_job_dependencies() { return 0; }; run_processor() { return 1; }; if run_campaign_plan fixture '$TMP_DIR/plan-failure.json'; then exit 1; else exit 0; fi"
+assert_rc_eq 0
 
 HELPER_CACHE="$TMP_DIR/helper-cache"
 run_case helper_hashlist_refresh bash -lc "source ./hash-cracker.sh; HASHLIST='$TMP_DIR/input'; POTFILE=/dev/null; SESSION_POT_UNIQUE_CACHE='$HELPER_CACHE'; SESSION_POT_LINES_LAST=0; SESSION_POT_BYTES_LAST=0; SESSION_POT_LINES_BASE=0; SESSION_POT_UNIQUE_BASE=0; SESSION_POT_BYTES_BASE=0; SESSION_POT_UNIQUE_CUR=0; SESSION_HASHLIST_PATH_LAST='$TMP_DIR/old-hashlist'; refresh_session_stats"
@@ -223,6 +251,74 @@ echo "[smoke] missing flag values fail before startup"
 run_case missing_flag_value bash -lc "./hash-cracker.sh --stats-export"
 assert_rc_eq 1
 assert_contains "Missing value for --stats-export"
+
+run_case campaign_missing_plan_value bash -lc "./hash-cracker.sh --plan"
+assert_rc_eq 1
+assert_contains "Missing value for --plan"
+
+run_case campaign_missing_plan_equals_value bash -lc "./hash-cracker.sh --plan="
+assert_rc_eq 1
+assert_contains "Missing value for --plan"
+
+run_case campaign_missing_plan_output bash -lc "./hash-cracker.sh --plan quick"
+assert_rc_eq 1
+assert_contains "Campaign plans require --output PATH."
+
+run_case campaign_missing_output_value bash -lc "./hash-cracker.sh --output"
+assert_rc_eq 1
+assert_contains "Missing value for --output"
+
+run_case campaign_missing_output_equals_value bash -lc "./hash-cracker.sh --output="
+assert_rc_eq 1
+assert_contains "Missing value for --output"
+
+run_case campaign_missing_execute_value bash -lc "./hash-cracker.sh --execute"
+assert_rc_eq 1
+assert_contains "Missing value for --execute"
+
+run_case campaign_missing_execute_equals_value bash -lc "./hash-cracker.sh --execute="
+assert_rc_eq 1
+assert_contains "Missing value for --execute"
+
+run_case campaign_missing_resume_value bash -lc "./hash-cracker.sh --resume"
+assert_rc_eq 1
+assert_contains "Missing value for --resume"
+
+run_case campaign_missing_resume_equals_value bash -lc "./hash-cracker.sh --resume="
+assert_rc_eq 1
+assert_contains "Missing value for --resume"
+
+run_case campaign_output_without_plan bash -lc "./hash-cracker.sh --output campaign.json"
+assert_rc_eq 1
+assert_contains "--output is only valid with --plan"
+
+run_case campaign_execute_resume_conflict bash -lc "./hash-cracker.sh --execute one.json --resume two.json"
+assert_rc_eq 1
+assert_contains "Use either --execute or --resume"
+
+run_case campaign_plan_execute_conflict bash -lc "./hash-cracker.sh --plan quick --output plan.json --execute plan.json"
+assert_rc_eq 1
+assert_contains "Use either --plan or --execute/--resume"
+
+run_case campaign_plan_job_conflict bash -lc "./hash-cracker.sh --plan quick --output plan.json --job 1"
+assert_rc_eq 1
+assert_contains "Use either --plan or --preset/--job"
+
+run_case campaign_execute_job_conflict bash -lc "./hash-cracker.sh --execute plan.json --job 1"
+assert_rc_eq 1
+assert_contains "Use either --execute/--resume or --preset/--job"
+
+run_case campaign_resume_preset_conflict bash -lc "./hash-cracker.sh --resume plan.json --preset quick"
+assert_rc_eq 1
+assert_contains "Use either --execute/--resume or --preset/--job"
+
+run_case campaign_interactive_job bash -lc "./hash-cracker.sh --plan 2 --output '$TMP_DIR/interactive-campaign.json'"
+assert_rc_eq 1
+assert_contains "requires interactive input or is unsupported"
+
+run_case campaign_invalid_preset bash -lc "./hash-cracker.sh --plan nope --output '$TMP_DIR/invalid-campaign.json'"
+assert_rc_eq 1
+assert_contains "Invalid campaign preset: nope"
 
 echo "[smoke] early informational and CLI validation modes are deterministic"
 run_case module_info bash -lc "./hash-cracker.sh --module-info"
@@ -558,6 +654,225 @@ assert_contains "| 9      | Iterate results"
 assert_contains "| ok      | 0"
 assert_contains "Preset: quick | planned: 2 | completed: 2 | failed: 0 | duration:"
 assert_contains "Preset 'quick' completed."
+
+echo "[smoke] campaign planning captures reproducible command steps"
+CAMPAIGN_PATH="$TMP_DIR/quick-campaign.json"
+run_case campaign_plan bash -lc "./hash-cracker.sh --plan quick --output '$CAMPAIGN_PATH'"
+assert_rc_eq 0
+assert_contains "Campaign plan ready: $CAMPAIGN_PATH"
+if ! python3 - "$CAMPAIGN_PATH" <<'PY'; then
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+assert manifest["schema_version"] == "1"
+assert manifest["status"] == "planned"
+assert manifest["campaign"]["jobs"] == [1, 9]
+assert len(manifest["steps"]) == 2
+assert all(step["commands"] for step in manifest["steps"])
+assert manifest["inputs"]["potfile"]["mutable"] is True
+PY
+    fail_with_log "campaign plan manifest was invalid" "$LAST_LOG"
+fi
+
+CAMPAIGN_JOB_PATH="$TMP_DIR/job-campaign.json"
+run_case campaign_plan_equals bash -lc "./hash-cracker.sh --plan=1 --output='$CAMPAIGN_JOB_PATH'"
+assert_rc_eq 0
+assert_contains "Campaign plan ready: $CAMPAIGN_JOB_PATH"
+
+echo "[smoke] campaign execution records completed steps and supports resume"
+run_case campaign_execute_equals bash -lc "SESSION_LOG_DIR='$TMP_DIR/campaign-logs' ./hash-cracker.sh --execute='$CAMPAIGN_PATH'"
+assert_rc_eq 0
+assert_contains "Campaign has no incomplete steps: $CAMPAIGN_PATH"
+if ! python3 - "$CAMPAIGN_PATH" <<'PY'; then
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+assert manifest["status"] == "completed"
+assert all(step["state"] == "completed" for step in manifest["steps"])
+assert all(step["executed_commands"] for step in manifest["steps"])
+PY
+    fail_with_log "completed campaign state was invalid" "$LAST_LOG"
+fi
+
+run_case campaign_resume_equals bash -lc "SESSION_LOG_DIR='$TMP_DIR/campaign-logs' ./hash-cracker.sh --resume='$CAMPAIGN_PATH'"
+assert_rc_eq 0
+assert_contains "Campaign has no incomplete steps: $CAMPAIGN_PATH"
+
+CAMPAIGN_FAIL_HASHCAT="$TMP_DIR/campaign-failing-hashcat"
+printf '#!/usr/bin/env bash\nexit 7\n' >"$CAMPAIGN_FAIL_HASHCAT"
+chmod +x "$CAMPAIGN_FAIL_HASHCAT"
+CAMPAIGN_FAIL_CONFIG="$TMP_DIR/campaign-failing.conf"
+cat >"$CAMPAIGN_FAIL_CONFIG" <<EOF
+HASHCAT=($CAMPAIGN_FAIL_HASHCAT)
+DEVICE=1
+HASHTYPE=1000
+HASHLIST=$TMP_DIR/input
+POTFILE=$TMP_DIR/hash-cracker.pot
+WORDLIST=$TMP_DIR/wordlist.txt
+WORDLIST2=$TMP_DIR/wordlist2.txt
+EOF
+CAMPAIGN_FAIL_PATH="$TMP_DIR/failing-campaign.json"
+run_case campaign_failure_plan bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_FAIL_CONFIG' ./hash-cracker.sh --plan=quick --output '$CAMPAIGN_FAIL_PATH'"
+assert_rc_eq 0
+run_case campaign_execute_failure bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_FAIL_CONFIG' SESSION_LOG_DIR='$TMP_DIR/failing-campaign-logs' ./hash-cracker.sh --execute '$CAMPAIGN_FAIL_PATH'"
+assert_rc_eq 7
+assert_contains "Campaign '$CAMPAIGN_FAIL_PATH' stopped at step-001-job-1 with rc=7."
+if ! python3 - "$CAMPAIGN_FAIL_PATH" <<'PY'; then
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+assert manifest["status"] == "failed"
+assert manifest["steps"][0]["state"] == "failed"
+assert manifest["steps"][0]["exit_code"] == 7
+PY
+    fail_with_log "failed campaign state was invalid" "$LAST_LOG"
+fi
+
+printf '#!/usr/bin/env bash\nexit 0\n' >"$CAMPAIGN_FAIL_HASHCAT"
+run_case campaign_resume_failure bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_FAIL_CONFIG' SESSION_LOG_DIR='$TMP_DIR/failing-campaign-logs' ./hash-cracker.sh --resume '$CAMPAIGN_FAIL_PATH'"
+assert_rc_eq 0
+assert_contains "Campaign has no incomplete steps: $CAMPAIGN_FAIL_PATH"
+if ! python3 - "$CAMPAIGN_FAIL_PATH" <<'PY'; then
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+assert manifest["status"] == "completed"
+assert manifest["steps"][0]["state"] == "completed"
+assert manifest["steps"][0]["attempts"] == 2
+PY
+    fail_with_log "resumed campaign state was invalid" "$LAST_LOG"
+fi
+
+printf 'changed\n' >"$TMP_DIR/wordlist2.txt"
+run_case campaign_stale_input bash -lc "SESSION_LOG_DIR='$TMP_DIR/campaign-logs' ./hash-cracker.sh --resume '$CAMPAIGN_PATH'"
+assert_rc_eq 1
+assert_contains "campaign input changed for wordlist2"
+printf 'test\n' >"$TMP_DIR/wordlist2.txt"
+
+run_case campaign_runtime_drift bash -lc "SESSION_LOG_DIR='$TMP_DIR/campaign-logs' ./hash-cracker.sh --resume '$CAMPAIGN_PATH' --no-limit"
+assert_rc_eq 1
+assert_contains "campaign runtime changed for kernel"
+
+CAMPAIGN_NEXT_FAILURE_BIN="$TMP_DIR/campaign-next-failure-bin"
+mkdir -p "$CAMPAIGN_NEXT_FAILURE_BIN"
+cat >"$CAMPAIGN_NEXT_FAILURE_BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+case "${2:-}" in
+    validate) exit 0 ;;
+    next) exit 1 ;;
+    *) exit 0 ;;
+esac
+EOF
+chmod +x "$CAMPAIGN_NEXT_FAILURE_BIN/python3"
+: >"$TMP_DIR/campaign-next-failure.json"
+run_case campaign_next_failure bash -lc "PATH='$CAMPAIGN_NEXT_FAILURE_BIN:$PATH' ./hash-cracker.sh --execute '$TMP_DIR/campaign-next-failure.json'"
+assert_rc_eq 1
+assert_contains "Unable to read the next campaign step."
+
+CAMPAIGN_MARK_RUNNING_FAILURE_BIN="$TMP_DIR/campaign-mark-running-failure-bin"
+mkdir -p "$CAMPAIGN_MARK_RUNNING_FAILURE_BIN"
+cat >"$CAMPAIGN_MARK_RUNNING_FAILURE_BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+case "${2:-}" in
+    validate) exit 0 ;;
+    next) printf '0|step-001-job-1|1|Brute force\n' ;;
+    mark-running) exit 1 ;;
+    *) exit 0 ;;
+esac
+EOF
+chmod +x "$CAMPAIGN_MARK_RUNNING_FAILURE_BIN/python3"
+: >"$TMP_DIR/campaign-mark-running-failure.json"
+run_case campaign_mark_running_failure bash -lc "PATH='$CAMPAIGN_MARK_RUNNING_FAILURE_BIN:$PATH' ./hash-cracker.sh --execute '$TMP_DIR/campaign-mark-running-failure.json'"
+assert_rc_eq 1
+
+CAMPAIGN_DEPENDENCY_FAILURE_BIN="$TMP_DIR/campaign-dependency-failure-bin"
+mkdir -p "$CAMPAIGN_DEPENDENCY_FAILURE_BIN"
+cat >"$CAMPAIGN_DEPENDENCY_FAILURE_BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = '-c' ]; then
+    exit 1
+fi
+case "${2:-}" in
+    validate) exit 0 ;;
+    next) printf '0|step-001-job-12|12|PACK rule\n' ;;
+    *) exit 0 ;;
+esac
+EOF
+chmod +x "$CAMPAIGN_DEPENDENCY_FAILURE_BIN/python3"
+: >"$TMP_DIR/campaign-dependency-failure.json"
+run_case campaign_dependency_failure bash -lc "PATH='$CAMPAIGN_DEPENDENCY_FAILURE_BIN:$PATH' ./hash-cracker.sh --execute '$TMP_DIR/campaign-dependency-failure.json'"
+assert_rc_eq 1
+assert_contains "Campaign '$TMP_DIR/campaign-dependency-failure.json' stopped at step-001-job-12 with rc=1."
+
+CAMPAIGN_UPDATE_FAILURE_BIN="$TMP_DIR/campaign-update-failure-bin"
+mkdir -p "$CAMPAIGN_UPDATE_FAILURE_BIN"
+cat >"$CAMPAIGN_UPDATE_FAILURE_BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+case "${2:-}" in
+    validate) exit 0 ;;
+    next) printf '0|step-001-job-1|1|Brute force\n' ;;
+    update) exit 1 ;;
+    *) exit 0 ;;
+esac
+EOF
+chmod +x "$CAMPAIGN_UPDATE_FAILURE_BIN/python3"
+: >"$TMP_DIR/campaign-update-failure.json"
+run_case campaign_update_failure bash -lc "PATH='$CAMPAIGN_UPDATE_FAILURE_BIN:$PATH' ./hash-cracker.sh --execute '$TMP_DIR/campaign-update-failure.json'"
+assert_rc_eq 1
+
+CAMPAIGN_INTERRUPT_HASHCAT="$TMP_DIR/campaign-interrupt-hashcat"
+cat >"$CAMPAIGN_INTERRUPT_HASHCAT" <<'EOF'
+#!/usr/bin/env bash
+kill -INT "$PPID"
+sleep 0.1
+exit 0
+EOF
+chmod +x "$CAMPAIGN_INTERRUPT_HASHCAT"
+CAMPAIGN_INTERRUPT_CONFIG="$TMP_DIR/campaign-interrupt.conf"
+cat >"$CAMPAIGN_INTERRUPT_CONFIG" <<EOF
+HASHCAT=($CAMPAIGN_INTERRUPT_HASHCAT)
+DEVICE=1
+HASHTYPE=1000
+HASHLIST=$TMP_DIR/input
+POTFILE=$TMP_DIR/hash-cracker.pot
+WORDLIST=$TMP_DIR/wordlist.txt
+WORDLIST2=$TMP_DIR/wordlist2.txt
+EOF
+CAMPAIGN_INTERRUPT_PATH="$TMP_DIR/interrupted-campaign.json"
+run_case campaign_interrupt_plan bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_INTERRUPT_CONFIG' ./hash-cracker.sh --plan 1 --output '$CAMPAIGN_INTERRUPT_PATH'"
+assert_rc_eq 0
+run_case campaign_interrupt_execute bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_INTERRUPT_CONFIG' SESSION_LOG_DIR='$TMP_DIR/interrupted-campaign-logs' ./hash-cracker.sh --execute '$CAMPAIGN_INTERRUPT_PATH'"
+assert_rc_eq 130
+assert_contains "Campaign '$CAMPAIGN_INTERRUPT_PATH' stopped at step-001-job-1 with rc=130."
+if ! python3 - "$CAMPAIGN_INTERRUPT_PATH" <<'PY'; then
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+assert manifest["status"] == "paused"
+assert manifest["steps"][0]["state"] == "interrupted"
+PY
+    fail_with_log "interrupted campaign state was invalid" "$LAST_LOG"
+fi
+
+printf '#!/usr/bin/env bash\nexit 0\n' >"$CAMPAIGN_INTERRUPT_HASHCAT"
+run_case campaign_interrupt_resume bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_INTERRUPT_CONFIG' SESSION_LOG_DIR='$TMP_DIR/interrupted-campaign-logs' ./hash-cracker.sh --resume '$CAMPAIGN_INTERRUPT_PATH'"
+assert_rc_eq 0
+if ! python3 - "$CAMPAIGN_INTERRUPT_PATH" <<'PY'; then
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+assert manifest["status"] == "completed"
+assert manifest["steps"][0]["state"] == "completed"
+assert manifest["steps"][0]["attempts"] == 2
+PY
+    fail_with_log "resumed interrupted campaign state was invalid" "$LAST_LOG"
+fi
 
 echo "[smoke] preset deep-plus dry-run reaches extended jobs"
 FAKE_COMMON_SUBSTR="$TMP_DIR/fake-common-substr.sh"


### PR DESCRIPTION
## What changed

- Add versioned JSON campaign manifests with `--plan`, `--execute`, and `--resume` modes.
- Capture resolved Hashcat command previews, immutable input fingerprints, runtime flags, per-step attempts, exit codes, and interruption state.
- Reject changed campaign inputs or runtime flags before execution.
- Expand smoke coverage for campaign success, failure, interruption, resume, and CLI validation.
- Keep coverage artifacts and the baseline ratchet reliable in CI.
- Document campaign usage and add an Unreleased entry.

## Why

The tool could run presets and dry-run commands, but it had no durable, resumable representation of an attack campaign. This adds reproducible execution state without invoking real Hashcat during planning.

## Validation

- `make test-smoke`
- Bash executable-line coverage: 100.00%
- Bash function coverage: 100.00%
- Coverage baseline ratchet satisfied
- `make lint`
- `shfmt -i 4 -ci -bn -d`
