### PR TITLE
Add checkpointed campaign resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Create and run a reproducible campaign plan (requires `python3`):
 ./hash-cracker.sh --resume campaign.json
 ```
 
-Campaign manifests record the ordered jobs, resolved Hashcat commands, immutable input fingerprints, per-step exit codes, and execution state. Plans never execute Hashcat. Execution resumes the first incomplete step and rejects changed configuration, runtime flags, hashlist, or wordlist inputs; the potfile is treated as mutable campaign state. Campaign sources are built-in presets or non-interactive job IDs: `1`, `9`, `10`, `11`, `12`, `13`, `14`, `16`, and `19`.
+Campaign manifests record the ordered jobs, resolved Hashcat commands, immutable input fingerprints, per-step exit codes, and command-level execution state. Plans never execute Hashcat. During execution, every Hashcat command receives a deterministic session name and restore-file path. If a run is interrupted, `--resume` skips completed commands and re-enters the interrupted command with the same session and `--restore`; failed commands are retried with a new session. Generated processor inputs used by the interrupted command are retained until that command completes. Campaign sidecar state is stored beside the manifest under `<manifest>.state`. Execution rejects changed configuration, runtime flags, hashlist, or wordlist inputs; the potfile is treated as mutable campaign state. Campaign sources are built-in presets or non-interactive job IDs: `1`, `9`, `10`, `11`, `12`, `13`, `14`, `16`, and `19`.
 
 Run the smoke suite with Bash coverage (requires `python3`):
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added reproducible campaign manifests with command previews, input fingerprints, atomic step state, execution, and resume support.
+- Added command-level campaign checkpoints with deterministic Hashcat sessions and restore-file support for exact interrupted-command resume.
 
 ## v6.5.0 - Coverage Gate
 

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -393,6 +393,105 @@ function campaign_record_command() {
     printf '%s\t%s\n' "$CAMPAIGN_CURRENT_STEP" "$command_line" >>"$CAMPAIGN_COMMAND_FILE"
 }
 
+function campaign_command_start() {
+    local result
+
+    if [ "${CAMPAIGN_MODE:-}" != 'execute' ]; then
+        return 0
+    fi
+    if [ -z "${CAMPAIGN_MANIFEST:-}" ]; then
+        status_error "Campaign command checkpoint is missing its manifest path."
+        return 1
+    fi
+
+    if ! result="$(python3 scripts/campaign.py command-start \
+        --manifest "$CAMPAIGN_MANIFEST" \
+        --index "$CAMPAIGN_STEP_INDEX" \
+        --step-id "$CAMPAIGN_STEP_ID" \
+        --command-index "$CAMPAIGN_COMMAND_INDEX")"; then
+        status_error "Unable to checkpoint campaign command $CAMPAIGN_COMMAND_INDEX."
+        return 1
+    fi
+
+    IFS=$'\t' read -r CAMPAIGN_COMMAND_STATE CAMPAIGN_SESSION_NAME \
+        CAMPAIGN_RESTORE_FILE CAMPAIGN_RESTORE CAMPAIGN_COMMAND_ARGS_FILE <<<"$result"
+    CAMPAIGN_COMMAND_INDEX=$((CAMPAIGN_COMMAND_INDEX + 1))
+    return 0
+}
+
+function campaign_command_record() {
+    local command_index="$1"
+    local preview="$2"
+
+    if [ "${CAMPAIGN_MODE:-}" != 'execute' ]; then
+        return 0
+    fi
+    if ! python3 scripts/campaign.py command-record \
+        --manifest "$CAMPAIGN_MANIFEST" \
+        --index "$CAMPAIGN_STEP_INDEX" \
+        --step-id "$CAMPAIGN_STEP_ID" \
+        --command-index "$command_index" \
+        --preview "$preview"; then
+        status_error "Unable to persist campaign command $command_index arguments."
+        return 1
+    fi
+    return 0
+}
+
+function campaign_command_preserve_inputs() {
+    local path
+    local -a preserve_args=()
+
+    if [ "${CAMPAIGN_MODE:-}" != 'execute' ]; then
+        return 0
+    fi
+    for path in "$@"; do
+        if [ -n "$path" ]; then
+            CAMPAIGN_PRESERVED_PATHS+=("$path")
+            preserve_args+=(--path "$path")
+        fi
+    done
+    if [ "${#preserve_args[@]}" -eq 0 ]; then
+        return 0
+    fi
+    if ! python3 scripts/campaign.py command-preserve \
+        --manifest "$CAMPAIGN_MANIFEST" \
+        --index "$CAMPAIGN_STEP_INDEX" \
+        --step-id "$CAMPAIGN_STEP_ID" \
+        --command-index "$CAMPAIGN_ACTIVE_COMMAND_INDEX" \
+        "${preserve_args[@]}"; then
+        status_error "Unable to preserve campaign command inputs."
+        return 1
+    fi
+    return 0
+}
+
+function campaign_command_finish() {
+    local command_index="$1"
+    local rc="$2"
+    local duration="$3"
+    local state='failed'
+
+    if [ "${CAMPAIGN_MODE:-}" != 'execute' ]; then
+        return 0
+    fi
+    if [ "$rc" -eq 0 ]; then
+        state='completed'
+    fi
+    if ! python3 scripts/campaign.py command-finish \
+        --manifest "$CAMPAIGN_MANIFEST" \
+        --index "$CAMPAIGN_STEP_INDEX" \
+        --step-id "$CAMPAIGN_STEP_ID" \
+        --command-index "$command_index" \
+        --state "$state" \
+        --exit-code "$rc" \
+        --duration "$duration"; then
+        status_error "Unable to persist campaign command $command_index state."
+        return 1
+    fi
+    return 0
+}
+
 function campaign_jobs_for_source() {
     local source="$1"
 
@@ -562,6 +661,12 @@ function run_campaign_execute() {
         # shellcheck disable=SC2034
         CAMPAIGN_MODE='execute'
         CAMPAIGN_CURRENT_STEP="$step_id"
+        CAMPAIGN_MANIFEST="$manifest"
+        CAMPAIGN_STEP_INDEX="$index"
+        CAMPAIGN_STEP_ID="$step_id"
+        CAMPAIGN_COMMAND_INDEX=0
+        CAMPAIGN_ACTIVE_COMMAND_INDEX=-1
+        CAMPAIGN_PRESERVED_PATHS=()
         CAMPAIGN_COMMAND_FILE="$command_file"
         CAMPAIGN_INTERRUPT_MARKER="$interrupt_marker"
         start_time=$(current_epoch_seconds)
@@ -626,12 +731,33 @@ function processor_cleanup() {
     local path
     for path in "$@"; do
         if [ -n "$path" ]; then
+            if campaign_path_preserved "$path"; then
+                continue
+            fi
             rm -f -- "$path" 2>/dev/null || true
         fi
     done
 }
 
+function campaign_path_preserved() {
+    local path="$1"
+    local preserved
+
+    if [ "${CAMPAIGN_MODE:-}" != 'execute' ]; then
+        return 1
+    fi
+    for preserved in "${CAMPAIGN_PRESERVED_PATHS[@]:-}"; do
+        if [ "$path" = "$preserved" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 function processor_interrupt() {
+    if [ "${CAMPAIGN_MODE:-}" = 'execute' ] && [ "${CAMPAIGN_ACTIVE_COMMAND_INDEX:--1}" -ge 0 ]; then
+        campaign_command_preserve_inputs "$@" || true
+    fi
     if [ -n "${CAMPAIGN_INTERRUPT_MARKER:-}" ]; then
         : >"$CAMPAIGN_INTERRUPT_MARKER"
     fi

--- a/scripts/campaign.py
+++ b/scripts/campaign.py
@@ -14,7 +14,8 @@ import tempfile
 from pathlib import Path
 
 
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2"
+LEGACY_SCHEMA_VERSION = "1"
 
 
 class CampaignError(Exception):
@@ -48,18 +49,39 @@ def load_manifest(path: str) -> dict:
     except (OSError, json.JSONDecodeError) as error:
         raise CampaignError(f"cannot read manifest {path}: {error}") from error
 
-    if manifest.get("schema_version") != SCHEMA_VERSION:
+    if manifest.get("schema_version") not in (LEGACY_SCHEMA_VERSION, SCHEMA_VERSION):
         raise CampaignError(
             f"unsupported campaign schema: {manifest.get('schema_version', 'missing')}"
         )
     if not isinstance(manifest.get("steps"), list) or not manifest["steps"]:
         raise CampaignError("campaign manifest has no steps")
+    campaign = manifest.setdefault("campaign", {})
+    campaign.setdefault(
+        "session_prefix",
+        f"hc-{hashlib.sha256(resolved_path(path).encode()).hexdigest()[:12]}",
+    )
+    for step in manifest["steps"]:
+        step.setdefault("commands", [])
+        step.setdefault("current_command", None)
+        for command in step["commands"]:
+            command.setdefault("state", "pending")
+            command.setdefault("session", None)
+            command.setdefault("restore_file", None)
+            command.setdefault("attempts", 0)
+            command.setdefault("exit_code", None)
+            command.setdefault("started_at", None)
+            command.setdefault("finished_at", None)
+            command.setdefault("duration_seconds", None)
+            command.setdefault("executed_preview", None)
+            command.setdefault("executed_argv", None)
+            command.setdefault("preserved_inputs", [])
     return manifest
 
 
 def write_manifest(path: str, manifest: dict) -> None:
     destination = Path(path).expanduser()
     destination.parent.mkdir(parents=True, exist_ok=True)
+    manifest["schema_version"] = SCHEMA_VERSION
     manifest["updated_at"] = timestamp()
 
     temporary_path = None
@@ -113,6 +135,28 @@ def read_steps(path: str) -> list[dict]:
     return steps
 
 
+def command_record(preview: str) -> dict:
+    try:
+        argv = shlex.split(preview)
+    except ValueError:
+        argv = [preview]
+    return {
+        "preview": preview,
+        "argv": argv,
+        "state": "pending",
+        "session": None,
+        "restore_file": None,
+        "attempts": 0,
+        "exit_code": None,
+        "started_at": None,
+        "finished_at": None,
+        "duration_seconds": None,
+        "executed_preview": None,
+        "executed_argv": None,
+        "preserved_inputs": [],
+    }
+
+
 def read_commands(path: str) -> dict[str, list[dict]]:
     commands: dict[str, list[dict]] = {}
     for raw_line in Path(path).read_text(encoding="utf-8").splitlines():
@@ -122,13 +166,7 @@ def read_commands(path: str) -> dict[str, list[dict]]:
             step_id, preview = raw_line.split("\t", 1)
         except ValueError as error:
             raise CampaignError(f"invalid campaign command record: {raw_line}") from error
-        try:
-            argv = shlex.split(preview)
-        except ValueError:
-            argv = [preview]
-        commands.setdefault(step_id, []).append(
-            {"preview": preview, "argv": argv}
-        )
+        commands.setdefault(step_id, []).append(command_record(preview))
     return commands
 
 
@@ -175,6 +213,9 @@ def create_manifest(args: argparse.Namespace) -> None:
             "name": args.name,
             "kind": args.kind,
             "jobs": [step["job"] for step in steps],
+            "session_prefix": (
+                f"hc-{hashlib.sha256(resolved_path(args.output).encode()).hexdigest()[:12]}"
+            ),
         },
         "inputs": input_metadata(args),
         "runtime": runtime_metadata(args),
@@ -219,22 +260,29 @@ def validate_manifest(args: argparse.Namespace) -> None:
 def next_step(args: argparse.Namespace) -> int:
     manifest = load_manifest(args.manifest)
     for index, step in enumerate(manifest["steps"]):
-        if step.get("state") != "completed":
+        if step.get("state") != "completed" or any(
+            command.get("state") != "completed" for command in step["commands"]
+        ):
             print(f"{index}|{step['id']}|{step['job']}|{step['name']}")
             return 0
     return 2
 
 
+def get_step(manifest: dict, index: int, step_id: str) -> dict:
+    try:
+        step = manifest["steps"][index]
+    except (IndexError, TypeError) as error:
+        raise CampaignError(f"invalid campaign step index: {index}") from error
+    if step["id"] != step_id:
+        raise CampaignError(
+            f"campaign step mismatch: expected {step['id']}, got {step_id}"
+        )
+    return step
+
+
 def mark_running(args: argparse.Namespace) -> None:
     manifest = load_manifest(args.manifest)
-    try:
-        step = manifest["steps"][args.index]
-    except (IndexError, TypeError) as error:
-        raise CampaignError(f"invalid campaign step index: {args.index}") from error
-    if step["id"] != args.step_id:
-        raise CampaignError(
-            f"campaign step mismatch: expected {step['id']}, got {args.step_id}"
-        )
+    step = get_step(manifest, args.index, args.step_id)
     step["state"] = "running"
     step["attempts"] = int(step.get("attempts", 0)) + 1
     step["started_at"] = timestamp()
@@ -244,16 +292,143 @@ def mark_running(args: argparse.Namespace) -> None:
     write_manifest(args.manifest, manifest)
 
 
+def campaign_state_dir(manifest_path: str) -> Path:
+    return Path(f"{Path(manifest_path).expanduser().resolve(strict=False)}.state")
+
+
+def command_start(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    step = get_step(manifest, args.index, args.step_id)
+    try:
+        command = step["commands"][args.command_index]
+    except (IndexError, TypeError) as error:
+        raise CampaignError(
+            f"invalid campaign command index: {args.command_index}"
+        ) from error
+
+    for previous in step["commands"][: args.command_index]:
+        if previous.get("state") not in ("completed", "failed"):
+            raise CampaignError(
+                f"campaign command order is blocked before index {args.command_index}"
+            )
+
+    if command.get("state") == "completed":
+        print("completed\t\t\t0\t")
+        return
+
+    was_running = command.get("state") == "running" and bool(
+        command.get("session")
+    )
+    if not was_running:
+        if command.get("restore_file"):
+            Path(command["restore_file"]).unlink(missing_ok=True)
+        if command.get("session"):
+            Path(
+                campaign_state_dir(args.manifest) / f"{command['session']}.argv"
+            ).unlink(missing_ok=True)
+        for preserved in command.get("preserved_inputs", []):
+            Path(preserved).unlink(missing_ok=True)
+        command["preserved_inputs"] = []
+        command["attempts"] = int(command.get("attempts", 0)) + 1
+        command["session"] = (
+            f"{manifest['campaign']['session_prefix']}-"
+            f"{step['id']}-cmd-{args.command_index:03d}-attempt-"
+            f"{command['attempts']:02d}"
+        )
+        command["restore_file"] = str(
+            campaign_state_dir(args.manifest) / f"{command['session']}.restore"
+        )
+        command["state"] = "running"
+        command["started_at"] = timestamp()
+        command["finished_at"] = None
+        command["exit_code"] = None
+        command["duration_seconds"] = None
+
+    restore_file = command.get("restore_file") or ""
+    restore = int(was_running and bool(restore_file) and Path(restore_file).is_file())
+    state_dir = campaign_state_dir(args.manifest)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    argv_file = ""
+    if was_running and command.get("executed_argv"):
+        argv_file = str(state_dir / f"{command['session']}.argv")
+        with Path(argv_file).open("wb") as stream:
+            for argument in command["executed_argv"]:
+                stream.write(argument.encode() + b"\0")
+    step["current_command"] = args.command_index
+    manifest["status"] = "running"
+    write_manifest(args.manifest, manifest)
+    print(f"running\t{command['session']}\t{restore_file}\t{restore}\t{argv_file}")
+
+
+def record_command(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    step = get_step(manifest, args.index, args.step_id)
+    try:
+        command = step["commands"][args.command_index]
+    except (IndexError, TypeError) as error:
+        raise CampaignError(
+            f"invalid campaign command index: {args.command_index}"
+        ) from error
+    try:
+        argv = shlex.split(args.preview)
+    except ValueError as error:
+        raise CampaignError(f"invalid campaign command preview: {error}") from error
+    if not argv:
+        raise CampaignError("campaign command preview is empty")
+    command["executed_preview"] = args.preview
+    command["executed_argv"] = argv
+    write_manifest(args.manifest, manifest)
+
+
+def preserve_command_inputs(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    step = get_step(manifest, args.index, args.step_id)
+    try:
+        command = step["commands"][args.command_index]
+    except (IndexError, TypeError) as error:
+        raise CampaignError(
+            f"invalid campaign command index: {args.command_index}"
+        ) from error
+    preserved = command.setdefault("preserved_inputs", [])
+    for value in args.path:
+        if Path(value).is_file() and value not in preserved:
+            preserved.append(value)
+    write_manifest(args.manifest, manifest)
+
+
+def command_finish(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    step = get_step(manifest, args.index, args.step_id)
+    try:
+        command = step["commands"][args.command_index]
+    except (IndexError, TypeError) as error:
+        raise CampaignError(
+            f"invalid campaign command index: {args.command_index}"
+        ) from error
+    if command.get("state") == "completed":
+        return
+    command["state"] = args.state
+    command["exit_code"] = args.exit_code
+    command["duration_seconds"] = args.duration
+    command["finished_at"] = timestamp()
+    if args.state == "completed" and command.get("restore_file"):
+        Path(command["restore_file"]).unlink(missing_ok=True)
+    if args.state == "completed" and command.get("session"):
+        Path(campaign_state_dir(args.manifest) / f"{command['session']}.argv").unlink(
+            missing_ok=True
+        )
+    if args.state == "completed":
+        for preserved in command.get("preserved_inputs", []):
+            Path(preserved).unlink(missing_ok=True)
+        command["preserved_inputs"] = []
+    if args.state == "completed":
+        step["current_command"] = None
+    write_manifest(args.manifest, manifest)
+
+
 def update_step(args: argparse.Namespace) -> None:
     manifest = load_manifest(args.manifest)
-    try:
-        step = manifest["steps"][args.index]
-    except (IndexError, TypeError) as error:
-        raise CampaignError(f"invalid campaign step index: {args.index}") from error
-    if step["id"] != args.step_id:
-        raise CampaignError(
-            f"campaign step mismatch: expected {step['id']}, got {args.step_id}"
-        )
+    step = get_step(manifest, args.index, args.step_id)
 
     step["state"] = args.state
     step["exit_code"] = args.exit_code
@@ -338,6 +513,41 @@ def parser() -> argparse.ArgumentParser:
     update.add_argument("--duration", type=int, required=True)
     update.add_argument("--commands-file")
     update.set_defaults(handler=update_step)
+
+    command_start_parser = commands.add_parser("command-start")
+    command_start_parser.add_argument("--manifest", required=True)
+    command_start_parser.add_argument("--index", type=int, required=True)
+    command_start_parser.add_argument("--step-id", required=True)
+    command_start_parser.add_argument("--command-index", type=int, required=True)
+    command_start_parser.set_defaults(handler=command_start)
+
+    command_finish_parser = commands.add_parser("command-finish")
+    command_finish_parser.add_argument("--manifest", required=True)
+    command_finish_parser.add_argument("--index", type=int, required=True)
+    command_finish_parser.add_argument("--step-id", required=True)
+    command_finish_parser.add_argument("--command-index", type=int, required=True)
+    command_finish_parser.add_argument(
+        "--state", choices=("completed", "failed"), required=True
+    )
+    command_finish_parser.add_argument("--exit-code", type=int, required=True)
+    command_finish_parser.add_argument("--duration", type=int, required=True)
+    command_finish_parser.set_defaults(handler=command_finish)
+
+    command_record_parser = commands.add_parser("command-record")
+    command_record_parser.add_argument("--manifest", required=True)
+    command_record_parser.add_argument("--index", type=int, required=True)
+    command_record_parser.add_argument("--step-id", required=True)
+    command_record_parser.add_argument("--command-index", type=int, required=True)
+    command_record_parser.add_argument("--preview", required=True)
+    command_record_parser.set_defaults(handler=record_command)
+
+    command_preserve_parser = commands.add_parser("command-preserve")
+    command_preserve_parser.add_argument("--manifest", required=True)
+    command_preserve_parser.add_argument("--index", type=int, required=True)
+    command_preserve_parser.add_argument("--step-id", required=True)
+    command_preserve_parser.add_argument("--command-index", type=int, required=True)
+    command_preserve_parser.add_argument("--path", action="append", required=True)
+    command_preserve_parser.set_defaults(handler=preserve_command_inputs)
 
     return command_parser
 

--- a/scripts/parameters.sh
+++ b/scripts/parameters.sh
@@ -297,10 +297,67 @@ done
 # Processors call "$HASHCAT ...", so we point HASHCAT to this function name.
 HASHCAT_BIN="$HASHCAT"
 run_hashcat() {
+    local command_index=-1
     local cmd_line
+    local command_start_time
+    local duration
     local rc
+    local finish_rc
+    local -a command_args=("$@")
 
-    printf -v cmd_line '%q ' "$HASHCAT_BIN" "$@"
+    if [ "${CAMPAIGN_MODE:-}" = 'execute' ]; then
+        # shellcheck disable=SC2034
+        CAMPAIGN_ACTIVE_COMMAND_INDEX=-1
+        command_index="$CAMPAIGN_COMMAND_INDEX"
+        if ! campaign_command_start; then
+            # shellcheck disable=SC2034
+            HASHCAT_FAILURE=1
+            return 1
+        fi
+        if [ "$CAMPAIGN_COMMAND_STATE" = 'completed' ]; then
+            return 0
+        fi
+        CAMPAIGN_ACTIVE_COMMAND_INDEX="$command_index"
+        if [ -n "$CAMPAIGN_COMMAND_ARGS_FILE" ]; then
+            command_args=()
+            while IFS= read -r -d '' restored_arg; do
+                command_args+=("$restored_arg")
+            done <"$CAMPAIGN_COMMAND_ARGS_FILE"
+            if [ "${command_args[0]:-}" != "$HASHCAT_BIN" ]; then
+                # shellcheck disable=SC2034
+                HASHCAT_FAILURE=1
+                status_error "Campaign command checkpoint has a different Hashcat executable."
+                return 1
+            fi
+            command_args=("${command_args[@]:1}")
+            if [ "$CAMPAIGN_RESTORE" -eq 1 ]; then
+                local has_restore=0
+                local restored_arg
+                for restored_arg in "${command_args[@]}"; do
+                    if [ "$restored_arg" = '--restore' ]; then
+                        has_restore=1
+                        break
+                    fi
+                done
+                if [ "$has_restore" -eq 0 ]; then
+                    command_args+=("--restore")
+                fi
+            fi
+        else
+            command_args+=("--session=$CAMPAIGN_SESSION_NAME")
+            command_args+=("--restore-file-path=$CAMPAIGN_RESTORE_FILE")
+            if [ "$CAMPAIGN_RESTORE" -eq 1 ]; then
+                command_args+=("--restore")
+            fi
+        fi
+    fi
+
+    printf -v cmd_line '%q ' "$HASHCAT_BIN" "${command_args[@]}"
+    if [ "$command_index" -ge 0 ] && ! campaign_command_record "$command_index" "${cmd_line% }"; then
+        # shellcheck disable=SC2034
+        HASHCAT_FAILURE=1
+        return 1
+    fi
     if [ -n "${CAMPAIGN_COMMAND_FILE:-}" ]; then
         campaign_record_command "${cmd_line% }"
     fi
@@ -311,8 +368,20 @@ run_hashcat() {
         return 0
     fi
 
-    "$HASHCAT_BIN" "$@"
+    command_start_time=$(current_epoch_seconds)
+    "$HASHCAT_BIN" "${command_args[@]}"
     rc=$?
+    duration=$(($(current_epoch_seconds) - command_start_time))
+
+    if [ "$command_index" -ge 0 ]; then
+        campaign_command_finish "$command_index" "$rc" "$duration"
+        finish_rc=$?
+        if [ "$finish_rc" -ne 0 ] && [ "$rc" -eq 0 ]; then
+            rc=1
+        fi
+        # shellcheck disable=SC2034
+        CAMPAIGN_ACTIVE_COMMAND_INDEX=-1
+    fi
 
     if [ $rc -ne 0 ]; then
         # shellcheck disable=SC2034

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -190,6 +190,55 @@ assert_rc_eq 0
 run_case helper_campaign_plan_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; campaign_jobs_for_source() { printf '1'; }; check_job_dependencies() { return 0; }; run_processor() { return 1; }; if run_campaign_plan fixture '$TMP_DIR/plan-failure.json'; then exit 1; else exit 0; fi"
 assert_rc_eq 0
 
+run_case helper_campaign_command_start_noop bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=plan; campaign_command_start"
+assert_rc_eq 0
+
+run_case helper_campaign_command_start_missing_manifest bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; unset CAMPAIGN_MANIFEST; if campaign_command_start; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_campaign_command_start_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_MANIFEST=fixture; CAMPAIGN_STEP_INDEX=0; CAMPAIGN_STEP_ID=step-001; CAMPAIGN_COMMAND_INDEX=0; python3() { return 1; }; if campaign_command_start; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_campaign_command_record_noop bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=plan; campaign_command_record 0 fixture"
+assert_rc_eq 0
+
+run_case helper_campaign_command_record_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_MANIFEST=fixture; CAMPAIGN_STEP_INDEX=0; CAMPAIGN_STEP_ID=step-001; python3() { return 1; }; if campaign_command_record 0 fixture; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_campaign_preserve_noop bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=plan; campaign_command_preserve_inputs '$TMP_DIR/input'"
+assert_rc_eq 0
+
+run_case helper_campaign_preserve_empty bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; campaign_command_preserve_inputs"
+assert_rc_eq 0
+
+run_case helper_campaign_preserve_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_MANIFEST=fixture; CAMPAIGN_STEP_INDEX=0; CAMPAIGN_STEP_ID=step-001; CAMPAIGN_ACTIVE_COMMAND_INDEX=0; CAMPAIGN_PRESERVED_PATHS=(); python3() { return 1; }; if campaign_command_preserve_inputs '$TMP_DIR/input'; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_campaign_command_finish_noop bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=plan; campaign_command_finish 0 0 0"
+assert_rc_eq 0
+
+run_case helper_campaign_command_finish_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_MANIFEST=fixture; CAMPAIGN_STEP_INDEX=0; CAMPAIGN_STEP_ID=step-001; python3() { return 1; }; if campaign_command_finish 0 0 0; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_run_hashcat_checkpoint_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; source '$REPO_ROOT/scripts/parameters.sh' --dry-run; CAMPAIGN_MODE=execute; CAMPAIGN_COMMAND_INDEX=0; campaign_command_start() { return 1; }; if run_hashcat fixture; then exit 1; else test \"\$?\" -eq 1; fi"
+assert_rc_eq 0
+
+run_case helper_run_hashcat_finish_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; source '$REPO_ROOT/scripts/parameters.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_COMMAND_INDEX=0; campaign_command_start() { CAMPAIGN_COMMAND_STATE=running; CAMPAIGN_SESSION_NAME=fixture; CAMPAIGN_RESTORE_FILE='$TMP_DIR/fixture.restore'; CAMPAIGN_RESTORE=0; CAMPAIGN_COMMAND_ARGS_FILE=; return 0; }; campaign_command_record() { return 0; }; campaign_command_finish() { return 1; }; if run_hashcat fixture; then exit 1; else test \"\$?\" -eq 1; fi"
+assert_rc_eq 0
+
+run_case helper_run_hashcat_record_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; source '$REPO_ROOT/scripts/parameters.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_COMMAND_INDEX=0; campaign_command_start() { CAMPAIGN_COMMAND_STATE=running; CAMPAIGN_SESSION_NAME=fixture; CAMPAIGN_RESTORE_FILE='$TMP_DIR/fixture.restore'; CAMPAIGN_RESTORE=0; CAMPAIGN_COMMAND_ARGS_FILE=; return 0; }; campaign_command_record() { return 1; }; if run_hashcat fixture; then exit 1; else test \"\$?\" -eq 1; fi"
+assert_rc_eq 0
+
+CAMPAIGN_RESTORE_MISMATCH_FILE="$TMP_DIR/campaign-restore-mismatch"
+printf 'wrong-hashcat\0' >"$CAMPAIGN_RESTORE_MISMATCH_FILE"
+run_case helper_run_hashcat_restore_mismatch bash -lc "source '$REPO_ROOT/hash-cracker.sh'; source '$REPO_ROOT/scripts/parameters.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_COMMAND_INDEX=0; campaign_command_start() { CAMPAIGN_COMMAND_STATE=running; CAMPAIGN_COMMAND_ARGS_FILE='$CAMPAIGN_RESTORE_MISMATCH_FILE'; CAMPAIGN_RESTORE=0; return 0; }; if run_hashcat fixture; then exit 1; else test \"\$?\" -eq 1; fi"
+assert_rc_eq 0
+
+CAMPAIGN_RESTORE_EXISTING_FILE="$TMP_DIR/campaign-restore-existing"
+printf '%s\0--restore\0' "$TMP_DIR/fake-hashcat" >"$CAMPAIGN_RESTORE_EXISTING_FILE"
+run_case helper_run_hashcat_existing_restore bash -lc "source '$REPO_ROOT/hash-cracker.sh'; source '$REPO_ROOT/scripts/parameters.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_COMMAND_INDEX=0; campaign_command_start() { CAMPAIGN_COMMAND_STATE=running; CAMPAIGN_COMMAND_ARGS_FILE='$CAMPAIGN_RESTORE_EXISTING_FILE'; CAMPAIGN_RESTORE=1; return 0; }; campaign_command_record() { return 0; }; campaign_command_finish() { return 0; }; run_hashcat fixture"
+assert_rc_eq 0
+
 HELPER_CACHE="$TMP_DIR/helper-cache"
 run_case helper_hashlist_refresh bash -lc "source ./hash-cracker.sh; HASHLIST='$TMP_DIR/input'; POTFILE=/dev/null; SESSION_POT_UNIQUE_CACHE='$HELPER_CACHE'; SESSION_POT_LINES_LAST=0; SESSION_POT_BYTES_LAST=0; SESSION_POT_LINES_BASE=0; SESSION_POT_UNIQUE_BASE=0; SESSION_POT_BYTES_BASE=0; SESSION_POT_UNIQUE_CUR=0; SESSION_HASHLIST_PATH_LAST='$TMP_DIR/old-hashlist'; refresh_session_stats"
 assert_rc_eq 0
@@ -665,11 +714,19 @@ import json
 import sys
 
 manifest = json.load(open(sys.argv[1], encoding="utf-8"))
-assert manifest["schema_version"] == "1"
+assert manifest["schema_version"] == "2"
 assert manifest["status"] == "planned"
 assert manifest["campaign"]["jobs"] == [1, 9]
+assert manifest["campaign"]["session_prefix"].startswith("hc-")
 assert len(manifest["steps"]) == 2
 assert all(step["commands"] for step in manifest["steps"])
+assert all(
+    command["state"] == "pending"
+    and command["attempts"] == 0
+    and command["session"] is None
+    for step in manifest["steps"]
+    for command in step["commands"]
+)
 assert manifest["inputs"]["potfile"]["mutable"] is True
 PY
     fail_with_log "campaign plan manifest was invalid" "$LAST_LOG"
@@ -687,11 +744,20 @@ assert_contains "Campaign has no incomplete steps: $CAMPAIGN_PATH"
 if ! python3 - "$CAMPAIGN_PATH" <<'PY'; then
 import json
 import sys
+from pathlib import Path
 
 manifest = json.load(open(sys.argv[1], encoding="utf-8"))
 assert manifest["status"] == "completed"
 assert all(step["state"] == "completed" for step in manifest["steps"])
 assert all(step["executed_commands"] for step in manifest["steps"])
+commands = [command for step in manifest["steps"] for command in step["commands"]]
+assert all(command["state"] == "completed" for command in commands)
+assert all(command["attempts"] == 1 for command in commands)
+assert all(command["session"] for command in commands)
+assert all(command["executed_preview"] for command in commands)
+assert all(command["executed_argv"] for command in commands)
+assert len({command["session"] for command in commands}) == len(commands)
+assert all(not Path(command["restore_file"]).exists() for command in commands)
 PY
     fail_with_log "completed campaign state was invalid" "$LAST_LOG"
 fi
@@ -701,7 +767,21 @@ assert_rc_eq 0
 assert_contains "Campaign has no incomplete steps: $CAMPAIGN_PATH"
 
 CAMPAIGN_FAIL_HASHCAT="$TMP_DIR/campaign-failing-hashcat"
-printf '#!/usr/bin/env bash\nexit 7\n' >"$CAMPAIGN_FAIL_HASHCAT"
+CAMPAIGN_FAIL_COUNT="$TMP_DIR/campaign-failing-count"
+rm -f "$CAMPAIGN_FAIL_COUNT"
+cat >"$CAMPAIGN_FAIL_HASHCAT" <<EOF
+#!/usr/bin/env bash
+count=0
+if [ -f "$CAMPAIGN_FAIL_COUNT" ]; then
+    count=\$(cat "$CAMPAIGN_FAIL_COUNT")
+fi
+count=\$((count + 1))
+printf '%s\n' "\$count" >"$CAMPAIGN_FAIL_COUNT"
+if [ "\$count" -eq 2 ]; then
+    exit 7
+fi
+exit 0
+EOF
 chmod +x "$CAMPAIGN_FAIL_HASHCAT"
 CAMPAIGN_FAIL_CONFIG="$TMP_DIR/campaign-failing.conf"
 cat >"$CAMPAIGN_FAIL_CONFIG" <<EOF
@@ -727,11 +807,16 @@ manifest = json.load(open(sys.argv[1], encoding="utf-8"))
 assert manifest["status"] == "failed"
 assert manifest["steps"][0]["state"] == "failed"
 assert manifest["steps"][0]["exit_code"] == 7
+commands = manifest["steps"][0]["commands"]
+assert commands[0]["state"] == "completed"
+assert commands[0]["attempts"] == 1
+assert commands[1]["state"] == "failed"
+assert commands[1]["attempts"] == 1
+assert all(command["state"] == "completed" for command in commands[2:])
 PY
     fail_with_log "failed campaign state was invalid" "$LAST_LOG"
 fi
 
-printf '#!/usr/bin/env bash\nexit 0\n' >"$CAMPAIGN_FAIL_HASHCAT"
 run_case campaign_resume_failure bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_FAIL_CONFIG' SESSION_LOG_DIR='$TMP_DIR/failing-campaign-logs' ./hash-cracker.sh --resume '$CAMPAIGN_FAIL_PATH'"
 assert_rc_eq 0
 assert_contains "Campaign has no incomplete steps: $CAMPAIGN_FAIL_PATH"
@@ -743,6 +828,10 @@ manifest = json.load(open(sys.argv[1], encoding="utf-8"))
 assert manifest["status"] == "completed"
 assert manifest["steps"][0]["state"] == "completed"
 assert manifest["steps"][0]["attempts"] == 2
+commands = manifest["steps"][0]["commands"]
+assert all(command["state"] == "completed" for command in commands)
+assert commands[0]["attempts"] == 1
+assert commands[1]["attempts"] == 2
 PY
     fail_with_log "resumed campaign state was invalid" "$LAST_LOG"
 fi
@@ -825,8 +914,22 @@ run_case campaign_update_failure bash -lc "PATH='$CAMPAIGN_UPDATE_FAILURE_BIN:$P
 assert_rc_eq 1
 
 CAMPAIGN_INTERRUPT_HASHCAT="$TMP_DIR/campaign-interrupt-hashcat"
+export CAMPAIGN_INTERRUPT_ARGS_FILE="$TMP_DIR/campaign-interrupt-args"
+export CAMPAIGN_INTERRUPT_RELEASE_FILE="$TMP_DIR/campaign-interrupt-release"
+rm -f "$CAMPAIGN_INTERRUPT_ARGS_FILE" "$CAMPAIGN_INTERRUPT_RELEASE_FILE"
 cat >"$CAMPAIGN_INTERRUPT_HASHCAT" <<'EOF'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CAMPAIGN_INTERRUPT_ARGS_FILE"
+for argument in "$@"; do
+    case "$argument" in
+        --restore-file-path=*)
+            : >"${argument#*=}"
+            ;;
+    esac
+done
+if [ -f "$CAMPAIGN_INTERRUPT_RELEASE_FILE" ]; then
+    exit 0
+fi
 kill -INT "$PPID"
 sleep 0.1
 exit 0
@@ -843,33 +946,64 @@ WORDLIST=$TMP_DIR/wordlist.txt
 WORDLIST2=$TMP_DIR/wordlist2.txt
 EOF
 CAMPAIGN_INTERRUPT_PATH="$TMP_DIR/interrupted-campaign.json"
-run_case campaign_interrupt_plan bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_INTERRUPT_CONFIG' ./hash-cracker.sh --plan 1 --output '$CAMPAIGN_INTERRUPT_PATH'"
+run_case campaign_interrupt_plan bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_INTERRUPT_CONFIG' ./hash-cracker.sh --plan 9 --output '$CAMPAIGN_INTERRUPT_PATH'"
 assert_rc_eq 0
 run_case campaign_interrupt_execute bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_INTERRUPT_CONFIG' SESSION_LOG_DIR='$TMP_DIR/interrupted-campaign-logs' ./hash-cracker.sh --execute '$CAMPAIGN_INTERRUPT_PATH'"
 assert_rc_eq 130
-assert_contains "Campaign '$CAMPAIGN_INTERRUPT_PATH' stopped at step-001-job-1 with rc=130."
+assert_contains "Campaign '$CAMPAIGN_INTERRUPT_PATH' stopped at step-001-job-9 with rc=130."
 if ! python3 - "$CAMPAIGN_INTERRUPT_PATH" <<'PY'; then
 import json
 import sys
+from pathlib import Path
 
 manifest = json.load(open(sys.argv[1], encoding="utf-8"))
 assert manifest["status"] == "paused"
 assert manifest["steps"][0]["state"] == "interrupted"
+command = manifest["steps"][0]["commands"][0]
+assert command["state"] == "running"
+assert command["attempts"] == 1
+assert command["session"]
+assert Path(command["restore_file"]).is_file()
+assert len(command["preserved_inputs"]) == 1
+assert Path(command["preserved_inputs"][0]).is_file()
 PY
     fail_with_log "interrupted campaign state was invalid" "$LAST_LOG"
 fi
 
-printf '#!/usr/bin/env bash\nexit 0\n' >"$CAMPAIGN_INTERRUPT_HASHCAT"
+: >"$CAMPAIGN_INTERRUPT_RELEASE_FILE"
 run_case campaign_interrupt_resume bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_INTERRUPT_CONFIG' SESSION_LOG_DIR='$TMP_DIR/interrupted-campaign-logs' ./hash-cracker.sh --resume '$CAMPAIGN_INTERRUPT_PATH'"
 assert_rc_eq 0
 if ! python3 - "$CAMPAIGN_INTERRUPT_PATH" <<'PY'; then
 import json
+import os
+import shlex
 import sys
+from pathlib import Path
 
 manifest = json.load(open(sys.argv[1], encoding="utf-8"))
 assert manifest["status"] == "completed"
 assert manifest["steps"][0]["state"] == "completed"
 assert manifest["steps"][0]["attempts"] == 2
+commands = manifest["steps"][0]["commands"]
+assert all(command["state"] == "completed" for command in commands)
+assert commands[0]["attempts"] == 1
+assert not Path(commands[0]["restore_file"]).exists()
+assert commands[0]["preserved_inputs"] == []
+logged = [
+    shlex.split(line)
+    for line in Path(os.environ["CAMPAIGN_INTERRUPT_ARGS_FILE"]).read_text().splitlines()
+]
+assert len(logged) >= 2
+preserved_paths = [
+    Path(argument) for argument in logged[0] if argument.startswith("/tmp/hash-cracker-tmp.")
+]
+assert preserved_paths
+assert all(not path.exists() for path in preserved_paths)
+assert "--restore" not in logged[0]
+assert "--restore" in logged[1]
+assert f"--session={commands[0]['session']}" in logged[0]
+assert f"--session={commands[0]['session']}" in logged[1]
+assert logged[1] == [argument for argument in logged[0] if argument != "--restore"] + ["--restore"]
 PY
     fail_with_log "resumed interrupted campaign state was invalid" "$LAST_LOG"
 fi


### PR DESCRIPTION
## What changed

- Add schema v2 command-level campaign checkpoints.
- Assign deterministic Hashcat sessions and restore-file paths for each executed command.
- Persist the exact executed argv and preserve generated processor inputs across interruption.
- Make `--resume` skip completed commands and restore the interrupted command with the same session.
- Retry failed commands with a new session.
- Add deterministic fake-Hashcat smoke coverage and document the behavior.

## Why

Campaign resume previously restarted the processor from its first Hashcat invocation, which could repeat completed work and regenerate different temporary inputs. The new checkpoint state makes interruption recovery precise and inspectable.

## Validation

- `make test-smoke`
- `make lint`
- shfmt format check
- Bash coverage: 100% line and function coverage
- Coverage baseline: satisfied at 100%
- Bash and Python syntax checks
