### PR TITLE
Release v6.6.0 "Campaign Control"

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v6.6.0 - Campaign Control
+
 ### Added
 
 - Added reproducible campaign manifests with command previews, input fingerprints, atomic step state, execution, and resume support.

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -50,7 +50,7 @@ function banner_center_line() {
 }
 
 function release_version_text() {
-    printf '%s' 'v6.5.0 "Coverage Gate"'
+    printf '%s' 'v6.6.0 "Campaign Control"'
 }
 
 function release_label_text() {

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1045,8 +1045,8 @@ assert_contains "Preset 'quick' completed."
 if [ ! -s "$PRESET_STATS_EXPORT_PATH" ]; then
     fail_with_log "preset stats export file was not created" "$LAST_LOG"
 fi
-if ! grep -Fq '"release": "v6.5.0 \"Coverage Gate\""' "$PRESET_STATS_EXPORT_PATH"; then
-    fail_with_log "preset stats export missing v6.5.0 release marker" "$PRESET_STATS_EXPORT_PATH"
+if ! grep -Fq '"release": "v6.6.0 \"Campaign Control\""' "$PRESET_STATS_EXPORT_PATH"; then
+    fail_with_log "preset stats export missing v6.6.0 release marker" "$PRESET_STATS_EXPORT_PATH"
 fi
 
 echo "[smoke] invalid --job selection fails clearly"


### PR DESCRIPTION
## Summary
- update the application release banner and version log to v6.6.0 "Campaign Control"
- keep the preset stats smoke assertion aligned with the release marker

## Validation
- `make lint`
- `make test-smoke`
- `COVERAGE_DIR=/var/tmp/hash-cracker-coverage-release-2 COVERAGE_TMP_ROOT=/var/tmp make coverage`
- Bash line and function coverage: 100%

After merge, tag this commit as `v6.6.0` and publish the GitHub release.