### PR TITLE
Prepare v6.7.0 "Execution Confidence"

### DIFF
--- a/.github/workflows/shell-quality.yml
+++ b/.github/workflows/shell-quality.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run smoke tests
         run: make test-smoke
 
+      - name: Run campaign tests
+        run: make test-campaign
+
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL_SOURCES := $(shell find . -type f -name '*.sh' ! -path './.git/*' ! -path './coverage/*' ! -path './scripts/extensions/*' | sort)
 
-.PHONY: lint format-check format qa test-smoke coverage coverage-check
+.PHONY: lint format-check format qa test test-smoke test-campaign coverage coverage-check
 
 lint:
 	@if ! command -v shellcheck >/dev/null 2>&1; then \
@@ -31,6 +31,12 @@ qa: lint format-check
 test-smoke:
 	@echo "Running smoke tests..."
 	@bash tests/smoke.sh
+
+test-campaign:
+	@echo "Running campaign tests..."
+	@python3 -m unittest discover -s tests -p 'test_*.py'
+
+test: test-campaign test-smoke
 
 coverage:
 	@echo "Running Bash coverage..."

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ These are only needed for specific menu options.
 
 #### macOS
 
+- Bundled native helpers support Apple Silicon (`arm64`) only; Intel macOS is not supported for those workflows.
 - `python3`
   - Needed for option `12` (PACK rulegen) and option `13` (PACK mask)
   - Option `12` requires `pyenchant`:
@@ -64,9 +65,11 @@ Notes:
 
 `hash-cracker.conf` is required and is loaded automatically on every start.
 
+The configuration is sourced as trusted Bash code. Only use a configuration file you created or reviewed locally; do not point `HASH_CRACKER_CONFIG` at untrusted input.
+
 The file must live in the repository root and define these settings:
 
-- `HASHCAT` - path to the `hashcat` binary
+- `HASHCAT` - path to the `hashcat` binary, preferably as a quoted Bash array assignment such as `HASHCAT=("/path with spaces/hashcat")`
 - `DEVICE` - value passed to `hashcat -d`
 - `HASHTYPE` - hash mode, for example `1000` for NTLM
 - `HASHLIST` - file containing target hashes
@@ -78,7 +81,7 @@ Current example:
 
 ```bash
 # Hashcat path
-HASHCAT=(/usr/local/bin/hashcat)
+HASHCAT=("/usr/local/bin/hashcat")
 
 # Device to Use (hashcat -d $DEVICE)
 DEVICE=1
@@ -87,14 +90,14 @@ DEVICE=1
 HASHTYPE=1000
 
 # File containing target hashes
-HASHLIST=input
+HASHLIST="input"
 
 # Potfile you want to use
-POTFILE=hash-cracker.pot
+POTFILE="hash-cracker.pot"
 
 # Wordlist(s)
-WORDLIST=wordlists/ignis-1M.txt
-WORDLIST2=wordlists/ignis-1K.txt
+WORDLIST="wordlists/ignis-1M.txt"
+WORDLIST2="wordlists/ignis-1K.txt"
 ```
 
 ## Usage
@@ -193,7 +196,7 @@ Create and run a reproducible campaign plan (requires `python3`):
 ./hash-cracker.sh --resume campaign.json
 ```
 
-Campaign manifests record the ordered jobs, resolved Hashcat commands, immutable input fingerprints, per-step exit codes, and command-level execution state. Plans never execute Hashcat. During execution, every Hashcat command receives a deterministic session name and restore-file path. If a run is interrupted, `--resume` skips completed commands and re-enters the interrupted command with the same session and `--restore`; failed commands are retried with a new session. Generated processor inputs used by the interrupted command are retained until that command completes. Campaign sidecar state is stored beside the manifest under `<manifest>.state`. Execution rejects changed configuration, runtime flags, hashlist, or wordlist inputs; the potfile is treated as mutable campaign state. Campaign sources are built-in presets or non-interactive job IDs: `1`, `9`, `10`, `11`, `12`, `13`, `14`, `16`, and `19`.
+Campaign manifests record the ordered jobs, resolved Hashcat commands, immutable input fingerprints, optional execution-artifact fingerprints, per-step exit codes, and command-level execution state. Plans never execute Hashcat. During execution, every Hashcat command receives a deterministic session name and restore-file path. If a run is interrupted, `--resume` skips completed commands and re-enters the interrupted command with the same session and `--restore`; failed commands are retried with a new session. Generated processor inputs used by the interrupted command are retained until that command completes. Campaign sidecar state is stored beside the manifest under `<manifest>.state`. A manifest is single-writer state: concurrent executions against the same campaign are unsupported. New manifests reject changed configuration, runtime flags, hashlist, wordlist, Hashcat, processor, selector, rule, or referenced helper artifacts when those fingerprints are present; older manifests continue to use their recorded input and runtime checks. These content fingerprints do not record native-binary source commits or toolchain provenance. The potfile is mutable campaign state and is expected to grow append-only during normal Hashcat execution; reductions trigger a safe statistics recount. Campaign sources are built-in presets or non-interactive job IDs: `1`, `9`, `10`, `11`, `12`, `13`, `14`, `16`, and `19`.
 
 Run the smoke suite with Bash coverage (requires `python3`):
 
@@ -299,6 +302,7 @@ When the tool starts successfully, it opens an interactive menu with these optio
   - Set `--no-session-log` to disable file logging
 - With `--stats-debug`, the tool prints which refresh path was used (`incremental` or `full recount`).
 - With `--stats-export`, current stats are written as JSON on each refresh cycle.
+- Session logs and requested JSON exports are local audit artifacts. JSON export write failures are fatal; default session-log failures are reported as warnings so a cracking run is not mistaken for a missing audit record.
 - Exported JSON includes a top-level `"schema_version"` for stable downstream parsing.
 - With `--stats-export-scope latest` (default), JSON contains the latest snapshot only.
 - With `--stats-export-scope all`, JSON also includes parsed history from `logs/session-*.log`.

--- a/VERSION.md
+++ b/VERSION.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## v6.7.0 - Execution Confidence
+
+### Added
+
+- Added deterministic isolated smoke fixtures and direct campaign contract tests that cover all 22 processors without GPU hardware, real Hashcat execution, network access, or developer-local configuration.
+- Added executable-line and function coverage reporting with a no-regression baseline ratchet and CI artifacts.
+- Added campaign execution-artifact fingerprints and exact argument validation to detect drift before resuming a campaign.
+
+### Changed
+
+- Hashcat and processor paths now preserve argument boundaries, including paths containing spaces.
+- Processor, helper, campaign, session-log, and JSON-export failures now propagate or report explicit status instead of being silently ignored.
+- Potfile statistics safely recount after rotation or byte-only growth, while normal sessions continue to expect append-only potfiles.
+- Trusted local configuration, Apple Silicon-only macOS support, single-writer campaign manifests, and audit-output behavior are now documented.
+
 ## v6.6.0 - Campaign Control
 
 ### Added

--- a/hash-cracker.conf.example
+++ b/hash-cracker.conf.example
@@ -1,5 +1,5 @@
 # Hashcat path
-HASHCAT=(/usr/local/bin/hashcat)
+HASHCAT=("/usr/local/bin/hashcat")
 
 # Device to Use (hashcat -d $DEVICE)
 DEVICE=1
@@ -8,11 +8,11 @@ DEVICE=1
 HASHTYPE=1000
 
 # File containing target hashes
-HASHLIST=input
+HASHLIST="input"
 
 # Potfile you want to use
-POTFILE=hash-cracker.pot
+POTFILE="hash-cracker.pot"
 
 # Wordlist(s)
-WORDLIST=wordlists/ignis-1M.txt
-WORDLIST2=wordlists/ignis-1K.txt
+WORDLIST="wordlists/ignis-1M.txt"
+WORDLIST2="wordlists/ignis-1K.txt"

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Author: crypt0rr - https://github.com/crypt0rr/
 
+CAMPAIGN_EPHEMERAL_FILES=()
+
 function init_colors() {
     if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
         COLOR_RED=$'\033[31m'
@@ -50,7 +52,7 @@ function banner_center_line() {
 }
 
 function release_version_text() {
-    printf '%s' 'v6.6.0 "Campaign Control"'
+    printf '%s' 'v6.7.0 "Execution Confidence"'
 }
 
 function release_label_text() {
@@ -375,14 +377,26 @@ function run_processor() {
 
     (
         HASHCAT_FAILURE=0
+        PROCESSOR_FAILURE=0
+        set -o pipefail
         # shellcheck source=/dev/null
         source "$selected_processor"
+        rc=$?
+        if [ "$rc" -ne 0 ]; then
+            exit "$rc"
+        fi
+        if [ "$PROCESSOR_FAILURE" -ne 0 ]; then
+            exit "$PROCESSOR_FAILURE"
+        fi
         if [ "$HASHCAT_FAILURE" -ne 0 ]; then
             exit "$HASHCAT_FAILURE"
         fi
     )
     rc=$?
     if [ -n "${CAMPAIGN_INTERRUPT_MARKER:-}" ] && [ -f "$CAMPAIGN_INTERRUPT_MARKER" ]; then
+        if [ "$rc" -ne 0 ] && [ "$rc" -ne 130 ]; then
+            return "$rc"
+        fi
         return 130
     fi
     return "$rc"
@@ -390,7 +404,27 @@ function run_processor() {
 
 function campaign_record_command() {
     local command_line="$1"
-    printf '%s\t%s\n' "$CAMPAIGN_CURRENT_STEP" "$command_line" >>"$CAMPAIGN_COMMAND_FILE"
+    shift
+    if ! python3 - "$CAMPAIGN_CURRENT_STEP" "$command_line" "$@" >>"$CAMPAIGN_COMMAND_FILE" <<'PY'; then
+import json
+import sys
+
+print(json.dumps({"step_id": sys.argv[1], "preview": sys.argv[2], "argv": sys.argv[3:]}))
+PY
+        status_error "Unable to record campaign command arguments."
+        return 1
+    fi
+    return 0
+}
+
+function campaign_register_ephemeral() {
+    local path
+
+    for path in "$@"; do
+        if [ -n "$path" ]; then
+            CAMPAIGN_EPHEMERAL_FILES+=("$path")
+        fi
+    done
 }
 
 function campaign_command_start() {
@@ -422,19 +456,34 @@ function campaign_command_start() {
 function campaign_command_record() {
     local command_index="$1"
     local preview="$2"
+    shift 2
+    local argv_file
 
     if [ "${CAMPAIGN_MODE:-}" != 'execute' ]; then
         return 0
+    fi
+    if ! argv_file=$(mktemp /tmp/hash-cracker-campaign-argv.XXXX); then
+        status_error "Unable to allocate campaign command argument storage."
+        return 1
+    fi
+    campaign_register_ephemeral "$argv_file"
+    if ! printf '%s\0' "$@" >"$argv_file"; then
+        rm -f -- "$argv_file"
+        status_error "Unable to stage campaign command arguments."
+        return 1
     fi
     if ! python3 scripts/campaign.py command-record \
         --manifest "$CAMPAIGN_MANIFEST" \
         --index "$CAMPAIGN_STEP_INDEX" \
         --step-id "$CAMPAIGN_STEP_ID" \
         --command-index "$command_index" \
-        --preview "$preview"; then
+        --preview "$preview" \
+        --argv-file "$argv_file"; then
+        rm -f -- "$argv_file"
         status_error "Unable to persist campaign command $command_index arguments."
         return 1
     fi
+    rm -f -- "$argv_file"
     return 0
 }
 
@@ -512,6 +561,43 @@ function campaign_jobs_for_source() {
     fi
 }
 
+function campaign_artifact_paths() {
+    local path
+
+    printf '%s\n' \
+        "$HASHCAT_BIN" \
+        hash-cracker.sh \
+        scripts/parameters.sh \
+        scripts/campaign.py \
+        scripts/linux.sh \
+        scripts/mac.sh \
+        scripts/runtime-overrides.sh \
+        scripts/extensions/hashtypes
+    find scripts/processors scripts/selectors scripts/rules \
+        scripts/extensions/pack-linux scripts/extensions/pack-mac \
+        -type f \( -name '*.sh' -o -name '*.config' -o -name '*.py' \) -print 2>/dev/null | LC_ALL=C sort
+    for path in \
+        "${COMMON_SUBSTR_BIN:-}" \
+        "${EXPANDER_BIN:-}" \
+        "${MKPASS_BIN:-}" \
+        "${CEWL:-}"; do
+        if [ -n "$path" ] && [ -f "$path" ]; then
+            printf '%s\n' "$path"
+        fi
+    done
+}
+
+function campaign_artifact_args() {
+    local artifact
+
+    CAMPAIGN_ARTIFACT_ARGS=()
+    while IFS= read -r artifact; do
+        if [ -n "$artifact" ]; then
+            CAMPAIGN_ARTIFACT_ARGS+=(--artifact "$artifact")
+        fi
+    done < <(campaign_artifact_paths)
+}
+
 function run_campaign_plan() {
     local source="$1"
     local output="$2"
@@ -526,6 +612,7 @@ function run_campaign_plan() {
     local rc
     local kind='preset'
     local -a job_ids
+    local -a campaign_args
 
     if [[ "$source" =~ ^[0-9]+$ ]]; then
         kind='job'
@@ -534,8 +621,16 @@ function run_campaign_plan() {
         return 1
     fi
 
-    step_file=$(mktemp /tmp/hash-cracker-campaign-steps.XXXX)
-    command_file=$(mktemp /tmp/hash-cracker-campaign-commands.XXXX)
+    if ! step_file=$(mktemp /tmp/hash-cracker-campaign-steps.XXXX); then
+        status_error "Unable to allocate campaign planning state."
+        return 1
+    fi
+    if ! command_file=$(mktemp /tmp/hash-cracker-campaign-commands.XXXX); then
+        rm -f -- "$step_file"
+        status_error "Unable to allocate campaign command state."
+        return 1
+    fi
+    campaign_register_ephemeral "$step_file" "$command_file"
     : >"$command_file"
     CAMPAIGN_MODE='plan'
     CAMPAIGN_COMMAND_FILE="$command_file"
@@ -557,6 +652,7 @@ function run_campaign_plan() {
             rm -f -- "$step_file" "$command_file"
             return 1
         fi
+        CAMPAIGN_TEMP_INDEX=0
         run_processor "$job_id"
         rc=$?
         if [ "$rc" -ne 0 ]; then
@@ -567,25 +663,30 @@ function run_campaign_plan() {
         index=$((index + 1))
     done
 
-    python3 scripts/campaign.py create \
-        --output "$output" \
-        --name "$source" \
-        --kind "$kind" \
-        --release "$(release_version_text)" \
-        --steps-file "$step_file" \
-        --commands-file "$command_file" \
-        --config "$CONFIGFILE" \
-        --hashlist "$HASHLIST" \
-        --potfile "$POTFILE" \
-        --wordlist "$WORDLIST" \
-        --wordlist2 "$WORDLIST2" \
-        --hashcat "$HASHCAT_BIN" \
-        --hashtype "$HASHTYPE" \
-        --machine "$MACHINE" \
-        --kernel="$KERNEL" \
-        --loopback="$LOOPBACK" \
-        --hwmon="$HWMON" \
+    campaign_artifact_args
+    campaign_args=(
+        python3 scripts/campaign.py create
+        --output "$output"
+        --name "$source"
+        --kind "$kind"
+        --release "$(release_version_text)"
+        --steps-file "$step_file"
+        --commands-file "$command_file"
+        --config "$CONFIGFILE"
+        --hashlist "$HASHLIST"
+        --potfile "$POTFILE"
+        --wordlist "$WORDLIST"
+        --wordlist2 "$WORDLIST2"
+        --hashcat "$HASHCAT_BIN"
+        --hashtype "$HASHTYPE"
+        --machine "$MACHINE"
+        --kernel="$KERNEL"
+        --loopback="$LOOPBACK"
+        --hwmon="$HWMON"
         --showcracked="$SHOWCRACKED"
+    )
+    campaign_args+=("${CAMPAIGN_ARTIFACT_ARGS[@]}")
+    "${campaign_args[@]}"
     rc=$?
     rm -f -- "$step_file" "$command_file"
     if [ "$rc" -eq 0 ]; then
@@ -611,24 +712,30 @@ function run_campaign_execute() {
     local state
     local update_rc
     local session_stats_line
+    local -a campaign_args
 
     if [ ! -f "$manifest" ]; then
         status_error "Campaign manifest not found: $manifest"
         return 1
     fi
-    if ! python3 scripts/campaign.py validate \
-        --manifest "$manifest" \
-        --config "$CONFIGFILE" \
-        --hashlist "$HASHLIST" \
-        --wordlist "$WORDLIST" \
-        --wordlist2 "$WORDLIST2" \
-        --hashcat "$HASHCAT_BIN" \
-        --hashtype "$HASHTYPE" \
-        --machine "$MACHINE" \
-        --kernel="$KERNEL" \
-        --loopback="$LOOPBACK" \
-        --hwmon="$HWMON" \
-        --showcracked="$SHOWCRACKED"; then
+    campaign_artifact_args
+    campaign_args=(
+        python3 scripts/campaign.py validate
+        --manifest "$manifest"
+        --config "$CONFIGFILE"
+        --hashlist "$HASHLIST"
+        --wordlist "$WORDLIST"
+        --wordlist2 "$WORDLIST2"
+        --hashcat "$HASHCAT_BIN"
+        --hashtype "$HASHTYPE"
+        --machine "$MACHINE"
+        --kernel="$KERNEL"
+        --loopback="$LOOPBACK"
+        --hwmon="$HWMON"
+        --showcracked="$SHOWCRACKED"
+    )
+    campaign_args+=("${CAMPAIGN_ARTIFACT_ARGS[@]}")
+    if ! "${campaign_args[@]}"; then
         return 1
     fi
 
@@ -654,8 +761,12 @@ function run_campaign_execute() {
             return 1
         fi
 
-        command_file=$(mktemp /tmp/hash-cracker-campaign-executed.XXXX)
+        if ! command_file=$(mktemp /tmp/hash-cracker-campaign-executed.XXXX); then
+            status_error "Unable to allocate campaign execution state."
+            return 1
+        fi
         interrupt_marker="${command_file}.interrupt"
+        campaign_register_ephemeral "$command_file" "$interrupt_marker"
         : >"$command_file"
         rm -f -- "$interrupt_marker"
         # shellcheck disable=SC2034
@@ -665,6 +776,7 @@ function run_campaign_execute() {
         CAMPAIGN_STEP_INDEX="$index"
         CAMPAIGN_STEP_ID="$step_id"
         CAMPAIGN_COMMAND_INDEX=0
+        CAMPAIGN_TEMP_INDEX=0
         CAMPAIGN_ACTIVE_COMMAND_INDEX=-1
         CAMPAIGN_PRESERVED_PATHS=()
         CAMPAIGN_COMMAND_FILE="$command_file"
@@ -703,7 +815,9 @@ function run_campaign_execute() {
         refresh_session_stats
         session_stats_line=$(build_session_stats_line)
         log_session_stats_line "$session_stats_line"
-        export_session_stats_json
+        if ! export_session_stats_json; then
+            return 1
+        fi
 
         if [ "$rc" -ne 0 ]; then
             status_error "Campaign '$manifest' stopped at $step_id with rc=$rc."
@@ -713,7 +827,56 @@ function run_campaign_execute() {
 }
 
 function hashcat_base() {
-    "$HASHCAT" $KERNEL --bitmap-max=24 -d $DEVICE $HWMON $SHOWCRACKED --potfile-path=$POTFILE -m$HASHTYPE $HASHLIST "$@"
+    local -a hashcat_args=()
+    local -a processor_args=()
+    local arg
+
+    if [ -n "$KERNEL" ] && [ "$KERNEL" != ' ' ]; then
+        hashcat_args+=("$KERNEL")
+    fi
+    hashcat_args+=(--bitmap-max=24 -d "$DEVICE")
+    if [ -n "$HWMON" ] && [ "$HWMON" != ' ' ]; then
+        hashcat_args+=("$HWMON")
+    fi
+    case "$SHOWCRACKED" in
+        '' | ' ') ;;
+        '-o /dev/null') hashcat_args+=(-o /dev/null) ;;
+        *) hashcat_args+=("$SHOWCRACKED") ;;
+    esac
+    hashcat_args+=("--potfile-path=$POTFILE" "-m$HASHTYPE" "$HASHLIST")
+
+    for arg in "$@"; do
+        if [ -n "$arg" ] && [ "$arg" != ' ' ]; then
+            processor_args+=("$arg")
+        fi
+    done
+
+    "$HASHCAT" "${hashcat_args[@]}" "${processor_args[@]}"
+}
+
+function processor_run() {
+    local rc
+
+    "$@"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        # shellcheck disable=SC2034
+        PROCESSOR_FAILURE="$rc"
+    fi
+    return "$rc"
+}
+
+function processor_require_file() {
+    local path="$1"
+    local label="${2:-Processor output}"
+
+    if [ ! -f "$path" ]; then
+        status_error "$label was not created: $path"
+        # shellcheck disable=SC2034
+        PROCESSOR_FAILURE=1
+        return 1
+    fi
+    return 0
 }
 
 function processor_bootstrap() {
@@ -755,14 +918,25 @@ function campaign_path_preserved() {
 }
 
 function processor_interrupt() {
+    local interrupt_rc=130
+    local preserve_rc=0
+
     if [ "${CAMPAIGN_MODE:-}" = 'execute' ] && [ "${CAMPAIGN_ACTIVE_COMMAND_INDEX:--1}" -ge 0 ]; then
-        campaign_command_preserve_inputs "$@" || true
+        if ! campaign_command_preserve_inputs "$@"; then
+            preserve_rc=1
+        fi
     fi
     if [ -n "${CAMPAIGN_INTERRUPT_MARKER:-}" ]; then
-        : >"$CAMPAIGN_INTERRUPT_MARKER"
+        if ! : >"$CAMPAIGN_INTERRUPT_MARKER"; then
+            preserve_rc=1
+        fi
     fi
-    processor_cleanup "$@"
-    exit 0
+    if [ "$preserve_rc" -eq 0 ]; then
+        processor_cleanup "$@"
+        exit "$interrupt_rc"
+    fi
+    status_error "Unable to preserve interrupted campaign inputs; cleanup was skipped."
+    exit 1
 }
 
 function dry_run_enabled() {
@@ -775,6 +949,21 @@ function dryrun_note() {
 
 function dryrun_tempfile() {
     local tag="${1:-tmp}"
+    local campaign_key
+    local campaign_id
+    local temp_index
+
+    if [ "${CAMPAIGN_MODE:-}" = 'plan' ] || [ "${CAMPAIGN_MODE:-}" = 'execute' ]; then
+        campaign_key="${CAMPAIGN_MANIFEST:-${CAMPAIGN_OUTPUT:-}}"
+        if [ -n "$campaign_key" ] && [ -n "${CAMPAIGN_CURRENT_STEP:-}" ]; then
+            temp_index="${CAMPAIGN_TEMP_INDEX:-0}"
+            CAMPAIGN_TEMP_INDEX=$((temp_index + 1))
+            campaign_id=$(printf '%s' "$campaign_key" | cksum | awk '{print $1}')
+            printf '/tmp/hash-cracker-campaign-%s-%s-%s-%s' \
+                "$campaign_id" "$CAMPAIGN_CURRENT_STEP" "$tag" "$temp_index"
+            return 0
+        fi
+    fi
     if dry_run_enabled; then
         printf '/tmp/hash-cracker-dryrun-%s-%d-%d' "$tag" "$BASHPID" "$RANDOM"
     else
@@ -817,9 +1006,16 @@ function count_hashlist_unique_entries() {
 }
 
 function cleanup_session_state() {
+    local path
+
     if [ -n "${SESSION_POT_UNIQUE_CACHE:-}" ]; then
         rm -f -- "$SESSION_POT_UNIQUE_CACHE" 2>/dev/null || true
     fi
+    for path in "${CAMPAIGN_EPHEMERAL_FILES[@]:-}"; do
+        if [ -n "$path" ]; then
+            rm -f -- "$path" 2>/dev/null || true
+        fi
+    done
 }
 
 function rebuild_unique_plaintext_cache() {
@@ -905,8 +1101,12 @@ function ensure_parent_dir() {
 
     parent=$(dirname "$path")
     if [ -n "$parent" ] && [ "$parent" != "." ]; then
-        mkdir -p "$parent" 2>/dev/null || true
+        if ! mkdir -p "$parent"; then
+            status_error "Unable to create output directory: $parent"
+            return 1
+        fi
     fi
+    return 0
 }
 
 function stats_export_scope() {
@@ -993,9 +1193,11 @@ function export_session_stats_json() {
         return 0
     fi
 
-    ensure_parent_dir "$out_path"
+    if ! ensure_parent_dir "$out_path"; then
+        return 1
+    fi
 
-    if [ "${SESSION_LOG_DISABLED:-0}" = '1' ]; then
+    if [ "${SESSION_LOG_DISABLED:-0}" = '1' ] || [ "${SESSION_LOG_AVAILABLE:-0}" -ne 1 ]; then
         log_enabled="false"
     else
         log_enabled="true"
@@ -1008,9 +1210,15 @@ function export_session_stats_json() {
     if [ "$export_scope" = 'all' ]; then
         history_json="$(export_session_stats_history_json)"
     fi
+
+    if [ -d "$out_path" ]; then
+        status_error "Unable to replace stats export: $out_path"
+        return 1
+    fi
+
     tmp_path="${out_path}.tmp.$$"
 
-    cat >"$tmp_path" <<EOF
+    if ! cat >"$tmp_path" <<EOF; then
 {
   "schema_version": "1",
   "generated_at": "$(json_escape "$generated_at")",
@@ -1040,8 +1248,17 @@ function export_session_stats_json() {
   "history": $history_json
 }
 EOF
+        rm -f -- "$tmp_path"
+        status_error "Unable to write stats export: $out_path"
+        return 1
+    fi
 
-    mv "$tmp_path" "$out_path" 2>/dev/null || true
+    if ! mv -- "$tmp_path" "$out_path"; then
+        rm -f -- "$tmp_path"
+        status_error "Unable to replace stats export: $out_path"
+        return 1
+    fi
+    return 0
 }
 
 function session_log_keep_count() {
@@ -1088,6 +1305,8 @@ function init_session_stats_logfile() {
     local session_stamp
     local keep_count
 
+    SESSION_LOG_AVAILABLE=0
+
     if [ "${SESSION_LOG_DISABLED:-0}" = '1' ]; then
         SESSION_STATS_LOGFILE=''
         return 0
@@ -1098,17 +1317,30 @@ function init_session_stats_logfile() {
     if [ -n "${SESSION_STATS_LOGFILE:-}" ]; then
         log_dir=$(dirname "$SESSION_STATS_LOGFILE")
         if [ -n "$log_dir" ] && [ "$log_dir" != "." ]; then
-            mkdir -p "$log_dir" 2>/dev/null || true
+            if ! mkdir -p "$log_dir"; then
+                status_bad "Unable to create session log directory: $log_dir"
+                SESSION_STATS_LOGFILE=''
+                return 1
+            fi
         fi
+        SESSION_LOG_AVAILABLE=1
         return 0
     fi
 
     session_stamp=$(date '+%Y%m%d-%H%M%S')
     SESSION_STATS_LOGFILE="$logs_dir/session-${session_stamp}-${BASHPID}.log"
 
-    mkdir -p "$logs_dir" 2>/dev/null || true
+    if ! mkdir -p "$logs_dir"; then
+        status_bad "Unable to create session log directory: $logs_dir"
+        SESSION_STATS_LOGFILE=''
+        return 1
+    fi
+    SESSION_LOG_AVAILABLE=1
     prune_session_logs "$logs_dir" "$keep_count"
-    ln -sfn "$(basename "$SESSION_STATS_LOGFILE")" "$logs_dir/latest.log" 2>/dev/null || true
+    if ! ln -sfn "$(basename "$SESSION_STATS_LOGFILE")" "$logs_dir/latest.log"; then
+        status_bad "Unable to update latest session log link: $logs_dir/latest.log"
+    fi
+    return 0
 }
 
 function log_session_stats_line() {
@@ -1117,7 +1349,12 @@ function log_session_stats_line() {
         return 0
     fi
 
-    printf '[%s] %s\n' "$(timestamp_now)" "$line" >>"$SESSION_STATS_LOGFILE" 2>/dev/null || true
+    if ! printf '[%s] %s\n' "$(timestamp_now)" "$line" >>"$SESSION_STATS_LOGFILE"; then
+        status_bad "Unable to append session stats log: $SESSION_STATS_LOGFILE"
+        SESSION_LOG_AVAILABLE=0
+        return 1
+    fi
+    return 0
 }
 
 function dashboard_line() {
@@ -1135,6 +1372,8 @@ function show_session_stats_dashboard() {
 
     if [ "${SESSION_LOG_DISABLED:-0}" = '1' ]; then
         log_state="disabled"
+    elif [ "${SESSION_LOG_AVAILABLE:-0}" -ne 1 ]; then
+        log_state="unavailable"
     else
         log_state="enabled"
     fi
@@ -1207,7 +1446,12 @@ function refresh_session_stats() {
     if [ "$SESSION_POT_LINES_CUR" -ne "$SESSION_POT_LINES_LAST" ] || [ "$SESSION_POT_BYTES_CUR" -ne "$SESSION_POT_BYTES_LAST" ]; then
         if [ "$SESSION_POT_LINES_CUR" -ge "$SESSION_POT_LINES_LAST" ] && [ "$SESSION_POT_BYTES_CUR" -ge "$SESSION_POT_BYTES_LAST" ]; then
             delta_lines=$((SESSION_POT_LINES_CUR - SESSION_POT_LINES_LAST))
-            update_unique_plaintexts_incremental "$delta_lines"
+            if [ "$delta_lines" -gt 0 ]; then
+                update_unique_plaintexts_incremental "$delta_lines"
+            elif [ "$SESSION_POT_BYTES_CUR" -gt "$SESSION_POT_BYTES_LAST" ]; then
+                stats_debug_note "Stats refresh mode: full recount (byte-only potfile growth)"
+                rebuild_unique_plaintext_cache
+            fi
         else
             status_heading "Refreshing session stats (recounting unique potfile plaintexts, this may take a moment)..."
             rebuild_unique_plaintext_cache
@@ -1307,7 +1551,9 @@ function run_single_job_mode() {
     refresh_session_stats
     session_stats_line=$(build_session_stats_line)
     log_session_stats_line "$session_stats_line"
-    export_session_stats_json
+    if ! export_session_stats_json; then
+        return 1
+    fi
 
     if [ "$selected" = "99" ]; then
         show_session_stats_dashboard
@@ -1344,7 +1590,11 @@ function run_single_job_mode() {
     refresh_session_stats
     session_stats_line=$(build_session_stats_line)
     log_session_stats_line "$session_stats_line"
-    export_session_stats_json
+    if ! export_session_stats_json; then
+        if [ "$rc" -eq 0 ]; then
+            rc=1
+        fi
+    fi
 
     return $rc
 }
@@ -1389,7 +1639,9 @@ function run_preset_mode() {
     refresh_session_stats
     session_stats_line=$(build_session_stats_line)
     log_session_stats_line "$session_stats_line"
-    export_session_stats_json
+    if ! export_session_stats_json; then
+        return 1
+    fi
 
     status_heading "Running preset '$preset_name' (jobs: $preset_jobs)"
     preset_start_time=$(current_epoch_seconds)
@@ -1427,7 +1679,9 @@ function run_preset_mode() {
         refresh_session_stats
         session_stats_line=$(build_session_stats_line)
         log_session_stats_line "$session_stats_line"
-        export_session_stats_json
+        if ! export_session_stats_json; then
+            return 1
+        fi
     done
 
     preset_end_time=$(current_epoch_seconds)
@@ -1453,7 +1707,9 @@ function menu() {
         echo
         session_stats_line=$(build_session_stats_line)
         log_session_stats_line "$session_stats_line"
-        export_session_stats_json
+        if ! export_session_stats_json; then
+            return 1
+        fi
 
         if [ "$DRYRUN" = ' ' ]; then
             read -r -p "Select job [0-22,99] or type exit [DRY-RUN MODE]: " START

--- a/scripts/campaign.py
+++ b/scripts/campaign.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 import shlex
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -30,6 +31,13 @@ def resolved_path(value: str) -> str:
     return str(Path(value).expanduser().resolve(strict=False))
 
 
+def resolved_executable(value: str) -> str:
+    candidate = value
+    if os.sep not in value:
+        candidate = shutil.which(value) or value
+    return resolved_path(candidate)
+
+
 def file_fingerprint(value: str) -> str:
     path = Path(value)
     if not path.is_file():
@@ -49,6 +57,8 @@ def load_manifest(path: str) -> dict:
     except (OSError, json.JSONDecodeError) as error:
         raise CampaignError(f"cannot read manifest {path}: {error}") from error
 
+    if not isinstance(manifest, dict):
+        raise CampaignError("campaign manifest must contain a JSON object")
     if manifest.get("schema_version") not in (LEGACY_SCHEMA_VERSION, SCHEMA_VERSION):
         raise CampaignError(
             f"unsupported campaign schema: {manifest.get('schema_version', 'missing')}"
@@ -56,14 +66,27 @@ def load_manifest(path: str) -> dict:
     if not isinstance(manifest.get("steps"), list) or not manifest["steps"]:
         raise CampaignError("campaign manifest has no steps")
     campaign = manifest.setdefault("campaign", {})
+    if not isinstance(campaign, dict):
+        raise CampaignError("campaign manifest has invalid campaign metadata")
     campaign.setdefault(
         "session_prefix",
         f"hc-{hashlib.sha256(resolved_path(path).encode()).hexdigest()[:12]}",
     )
     for step in manifest["steps"]:
+        if not isinstance(step, dict):
+            raise CampaignError("campaign manifest contains an invalid step")
+        for field in ("id", "job", "name"):
+            if field not in step:
+                raise CampaignError(f"campaign step is missing '{field}'")
         step.setdefault("commands", [])
         step.setdefault("current_command", None)
+        if not isinstance(step["commands"], list):
+            raise CampaignError(f"campaign step has invalid commands: {step['id']}")
         for command in step["commands"]:
+            if not isinstance(command, dict):
+                raise CampaignError(
+                    f"campaign step has an invalid command: {step['id']}"
+                )
             command.setdefault("state", "pending")
             command.setdefault("session", None)
             command.setdefault("restore_file", None)
@@ -135,14 +158,15 @@ def read_steps(path: str) -> list[dict]:
     return steps
 
 
-def command_record(preview: str) -> dict:
-    try:
-        argv = shlex.split(preview)
-    except ValueError:
-        argv = [preview]
+def command_record(preview: str, argv: list[str] | None = None) -> dict:
+    if argv is None:
+        try:
+            argv = shlex.split(preview)
+        except ValueError as error:
+            raise CampaignError(f"invalid campaign command preview: {error}") from error
     return {
         "preview": preview,
-        "argv": argv,
+        "argv": list(argv),
         "state": "pending",
         "session": None,
         "restore_file": None,
@@ -162,6 +186,24 @@ def read_commands(path: str) -> dict[str, list[dict]]:
     for raw_line in Path(path).read_text(encoding="utf-8").splitlines():
         if not raw_line.strip():
             continue
+        if raw_line.lstrip().startswith("{"):
+            try:
+                record = json.loads(raw_line)
+                step_id = record["step_id"]
+                preview = record["preview"]
+                argv = record["argv"]
+            except (KeyError, TypeError, json.JSONDecodeError) as error:
+                raise CampaignError(
+                    f"invalid campaign command record: {raw_line}"
+                ) from error
+            if not isinstance(step_id, str) or not isinstance(preview, str):
+                raise CampaignError(f"invalid campaign command record: {raw_line}")
+            if not isinstance(argv, list) or not all(
+                isinstance(value, str) for value in argv
+            ):
+                raise CampaignError(f"invalid campaign command arguments: {raw_line}")
+            commands.setdefault(step_id, []).append(command_record(preview, argv))
+            continue
         try:
             step_id, preview = raw_line.split("\t", 1)
         except ValueError as error:
@@ -177,6 +219,9 @@ def input_metadata(args: argparse.Namespace) -> dict:
         "wordlist": args.wordlist,
         "wordlist2": args.wordlist2,
     }
+    for name, path in paths.items():
+        if not Path(path).is_file():
+            raise CampaignError(f"campaign input missing for {name}: {resolved_path(path)}")
     metadata = {
         name: {"path": resolved_path(path), "sha256": file_fingerprint(path)}
         for name, path in paths.items()
@@ -197,11 +242,47 @@ def runtime_metadata(args: argparse.Namespace) -> dict:
     }
 
 
+def artifact_metadata(paths: list[str]) -> list[dict[str, str]]:
+    artifacts = []
+    seen = set()
+    for value in paths:
+        if not value:
+            continue
+        path = resolved_executable(value)
+        if path in seen:
+            continue
+        seen.add(path)
+        artifacts.append({"path": path, "sha256": file_fingerprint(path)})
+    return artifacts
+
+
+def validate_output_path(args: argparse.Namespace, artifacts: list[dict[str, str]]) -> None:
+    output = resolved_path(args.output)
+    protected = [args.config, args.hashlist, args.wordlist, args.wordlist2, args.potfile]
+    protected.extend(item["path"] for item in artifacts)
+    for path in protected:
+        if output == resolved_path(path):
+            raise CampaignError(
+                f"campaign output conflicts with protected path: {output}"
+            )
+
+
 def create_manifest(args: argparse.Namespace) -> None:
     steps = read_steps(args.steps_file)
     commands = read_commands(args.commands_file)
+    step_ids = {step["id"] for step in steps}
+    unknown_commands = set(commands) - step_ids
+    if unknown_commands:
+        raise CampaignError(
+            f"campaign commands contain unknown steps: {', '.join(sorted(unknown_commands))}"
+        )
     for step in steps:
         step["commands"] = commands.get(step["id"], [])
+        if not step["commands"]:
+            raise CampaignError(f"campaign step has no recorded commands: {step['id']}")
+
+    artifacts = artifact_metadata(getattr(args, "artifact", []))
+    validate_output_path(args, artifacts)
 
     manifest = {
         "schema_version": SCHEMA_VERSION,
@@ -219,6 +300,7 @@ def create_manifest(args: argparse.Namespace) -> None:
         },
         "inputs": input_metadata(args),
         "runtime": runtime_metadata(args),
+        "artifacts": artifacts,
         "steps": steps,
     }
     write_manifest(args.output, manifest)
@@ -228,12 +310,39 @@ def create_manifest(args: argparse.Namespace) -> None:
 
 def validate_manifest(args: argparse.Namespace) -> None:
     manifest = load_manifest(args.manifest)
+    expected_artifacts = manifest.get("artifacts")
+    if expected_artifacts is not None:
+        if not isinstance(expected_artifacts, list) or not expected_artifacts:
+            raise CampaignError("campaign manifest has invalid artifact fingerprints")
+        if any(
+            not isinstance(artifact, dict)
+            or not isinstance(artifact.get("path"), str)
+            or not isinstance(artifact.get("sha256"), str)
+            for artifact in expected_artifacts
+        ):
+            raise CampaignError("campaign manifest has invalid artifact fingerprints")
+        current_artifacts = artifact_metadata(getattr(args, "artifact", []))
+        expected_by_path = {
+            artifact.get("path"): artifact for artifact in expected_artifacts
+        }
+        current_by_path = {artifact["path"]: artifact for artifact in current_artifacts}
+        if set(expected_by_path) != set(current_by_path):
+            raise CampaignError("campaign artifact set changed; create a new plan")
+        for path, expected in expected_by_path.items():
+            if expected.get("sha256") != current_by_path[path].get("sha256"):
+                raise CampaignError(f"campaign artifact changed: {path}")
+
     current_paths = {
         "config": args.config,
         "hashlist": args.hashlist,
         "wordlist": args.wordlist,
         "wordlist2": args.wordlist2,
     }
+    for name, current_path in current_paths.items():
+        if not Path(current_path).is_file():
+            raise CampaignError(
+                f"campaign input missing for {name}: {resolved_path(current_path)}"
+            )
     for name, current_path in current_paths.items():
         expected = manifest["inputs"].get(name, {})
         current_resolved = resolved_path(current_path)
@@ -369,12 +478,41 @@ def record_command(args: argparse.Namespace) -> None:
         raise CampaignError(
             f"invalid campaign command index: {args.command_index}"
         ) from error
-    try:
-        argv = shlex.split(args.preview)
-    except ValueError as error:
-        raise CampaignError(f"invalid campaign command preview: {error}") from error
+    if getattr(args, "argv_file", None):
+        try:
+            raw_args = Path(args.argv_file).read_bytes()
+            if raw_args and not raw_args.endswith(b"\0"):
+                raise CampaignError("campaign command argument record is not NUL terminated")
+            argv = [value.decode("utf-8") for value in raw_args.split(b"\0")[:-1]]
+        except (OSError, UnicodeDecodeError) as error:
+            raise CampaignError(f"invalid campaign command arguments: {error}") from error
+    else:
+        try:
+            argv = shlex.split(args.preview)
+        except ValueError as error:
+            raise CampaignError(f"invalid campaign command preview: {error}") from error
     if not argv:
         raise CampaignError("campaign command preview is empty")
+    planned_argv = command.get("argv") or []
+    stable_planned_argv = [
+        value
+        for value in planned_argv
+        if value != "--restore"
+        and not value.startswith("--session=")
+        and not value.startswith("--restore-file-path=")
+    ]
+    stable_executed_argv = [
+        value
+        for value in argv
+        if value != "--restore"
+        and not value.startswith("--session=")
+        and not value.startswith("--restore-file-path=")
+    ]
+    if stable_executed_argv != stable_planned_argv:
+        raise CampaignError(
+            f"campaign command changed at step {args.step_id}, command {args.command_index}; "
+            "create a new plan"
+        )
     command["executed_preview"] = args.preview
     command["executed_argv"] = argv
     write_manifest(args.manifest, manifest)
@@ -475,6 +613,7 @@ def parser() -> argparse.ArgumentParser:
     create.add_argument("--loopback", required=True)
     create.add_argument("--hwmon", required=True)
     create.add_argument("--showcracked", required=True)
+    create.add_argument("--artifact", action="append", default=[])
     create.set_defaults(handler=create_manifest)
 
     validate = commands.add_parser("validate")
@@ -490,6 +629,7 @@ def parser() -> argparse.ArgumentParser:
     validate.add_argument("--loopback", required=True)
     validate.add_argument("--hwmon", required=True)
     validate.add_argument("--showcracked", required=True)
+    validate.add_argument("--artifact", action="append", default=[])
     validate.set_defaults(handler=validate_manifest)
 
     next_command = commands.add_parser("next")
@@ -539,6 +679,7 @@ def parser() -> argparse.ArgumentParser:
     command_record_parser.add_argument("--step-id", required=True)
     command_record_parser.add_argument("--command-index", type=int, required=True)
     command_record_parser.add_argument("--preview", required=True)
+    command_record_parser.add_argument("--argv-file")
     command_record_parser.set_defaults(handler=record_command)
 
     command_preserve_parser = commands.add_parser("command-preserve")
@@ -556,7 +697,15 @@ def main() -> int:
     args = parser().parse_args()
     try:
         result = args.handler(args)
-    except (CampaignError, OSError, ValueError) as error:
+    except (
+        CampaignError,
+        OSError,
+        UnicodeError,
+        ValueError,
+        KeyError,
+        TypeError,
+        AttributeError,
+    ) as error:
         print(f"campaign: {error}", file=sys.stderr)
         return 1
     return result if isinstance(result, int) else 0

--- a/scripts/parameters.sh
+++ b/scripts/parameters.sh
@@ -285,7 +285,7 @@ fi
 # shellcheck source=/dev/null
 source "$CONFIGFILE"
 
-REQUIRED_CONFIG_VARS=(HASHCAT HASHTYPE HASHLIST POTFILE WORDLIST WORDLIST2)
+REQUIRED_CONFIG_VARS=(HASHCAT DEVICE HASHTYPE HASHLIST POTFILE WORDLIST WORDLIST2)
 for REQUIRED_CONFIG_VAR in "${REQUIRED_CONFIG_VARS[@]}"; do
     if [ -z "${!REQUIRED_CONFIG_VAR}" ]; then
         status_error "Missing required setting '$REQUIRED_CONFIG_VAR' in $CONFIGFILE"
@@ -353,13 +353,17 @@ run_hashcat() {
     fi
 
     printf -v cmd_line '%q ' "$HASHCAT_BIN" "${command_args[@]}"
-    if [ "$command_index" -ge 0 ] && ! campaign_command_record "$command_index" "${cmd_line% }"; then
+    if [ "$command_index" -ge 0 ] && ! campaign_command_record "$command_index" "${cmd_line% }" "$HASHCAT_BIN" "${command_args[@]}"; then
         # shellcheck disable=SC2034
         HASHCAT_FAILURE=1
         return 1
     fi
     if [ -n "${CAMPAIGN_COMMAND_FILE:-}" ]; then
-        campaign_record_command "${cmd_line% }"
+        if ! campaign_record_command "${cmd_line% }" "$HASHCAT_BIN" "${command_args[@]}"; then
+            # shellcheck disable=SC2034
+            HASHCAT_FAILURE=1
+            return 1
+        fi
     fi
 
     if [ "$DRYRUN" = ' ' ]; then

--- a/scripts/processors/10-prefixsuffix.sh
+++ b/scripts/processors/10-prefixsuffix.sh
@@ -6,10 +6,10 @@ processor_bootstrap
 common_substr_bin="${COMMON_SUBSTR_BIN:-scripts/extensions/common-substr-linux}"
 
 # Temporary Files
-tmp=$(dryrun_tempfile prefixsuffix)
-tmp2=$(dryrun_tempfile prefixsuffix)
-tmp3=$(dryrun_tempfile prefixsuffix)
-tmp4=$(dryrun_tempfile prefixsuffix)
+tmp=$(dryrun_tempfile prefixsuffix-1)
+tmp2=$(dryrun_tempfile prefixsuffix-2)
+tmp3=$(dryrun_tempfile prefixsuffix-3)
+tmp4=$(dryrun_tempfile prefixsuffix-4)
 trap 'processor_interrupt "$tmp" "$tmp2" "$tmp3" "$tmp4"' INT TERM
 trap 'processor_cleanup "$tmp" "$tmp2" "$tmp3" "$tmp4"' EXIT
 
@@ -22,17 +22,26 @@ if dry_run_enabled; then
         dryrun_note "would run common-substr-linux prefix/suffix generation into $tmp3 and $tmp4"
     fi
 else
-    cat $POTFILE | awk -F: '{print $NF}' | tee $tmp &>/dev/null
-    if [ "$MACHINE" == "Mac" ]; then
-        cat $tmp | awk -F: '{print $NF}' | sort | tee $tmp2 &>/dev/null && "$common_substr_bin" -n -p -f $tmp2 >$tmp3 && "$common_substr_bin" -n -s -f $tmp2 >$tmp4 && rm $tmp2 $tmp
-    else
-        cat $tmp | awk -F: '{print $NF}' | sort | tee $tmp2 &>/dev/null && "$common_substr_bin" -n -p -f $tmp2 >$tmp3 && "$common_substr_bin" -n -s -f $tmp2 >$tmp4 && rm $tmp2 $tmp
+    if ! cat "$POTFILE" | awk -F: '{print $NF}' | tee "$tmp" &>/dev/null; then
+        status_error "Prefix/suffix plaintext extraction failed."
+        exit 1
     fi
+    if ! {
+        cat "$tmp" | awk -F: '{print $NF}' | sort | tee "$tmp2" &>/dev/null \
+            && "$common_substr_bin" -n -p -f "$tmp2" >"$tmp3" \
+            && "$common_substr_bin" -n -s -f "$tmp2" >"$tmp4" \
+            && rm -f -- "$tmp2" "$tmp"
+    }; then
+        status_error "Prefix/suffix helper preprocessing failed."
+        exit 1
+    fi
+    processor_require_file "$tmp3" "Prefix output" || exit 1
+    processor_require_file "$tmp4" "Suffix output" || exit 1
 fi
 
-hashcat_base -a1 $tmp3 $tmp4
-hashcat_base -a1 $tmp4 $tmp3
+hashcat_base -a1 "$tmp3" "$tmp4"
+hashcat_base -a1 "$tmp4" "$tmp3"
 if ! dry_run_enabled; then
-    rm $tmp3 $tmp4
+    rm -f -- "$tmp3" "$tmp4"
 fi
 echo -e "\nPrefix suffix processing done\n"

--- a/scripts/processors/11-commonsubstring.sh
+++ b/scripts/processors/11-commonsubstring.sh
@@ -6,9 +6,9 @@ processor_bootstrap
 common_substr_bin="${COMMON_SUBSTR_BIN:-scripts/extensions/common-substr-linux}"
 
 # Temporary Files
-tmp2=$(dryrun_tempfile commonsubstr)
-tmp3=$(dryrun_tempfile commonsubstr)
-tmp4=$(dryrun_tempfile commonsubstr)
+tmp2=$(dryrun_tempfile commonsubstr-2)
+tmp3=$(dryrun_tempfile commonsubstr-3)
+tmp4=$(dryrun_tempfile commonsubstr-4)
 trap 'processor_interrupt "$tmp2" "$tmp3" "$tmp4"' INT TERM
 trap 'processor_cleanup "$tmp2" "$tmp3" "$tmp4"' EXIT
 
@@ -21,12 +21,19 @@ if dry_run_enabled; then
         dryrun_note "would run common-substr-linux generation into $tmp4"
     fi
 else
-    awk -F: '{print $NF}' "$POTFILE" >"$tmp2"
-    if [ "$MACHINE" == "Mac" ]; then
-        sort "$tmp2" | tee "$tmp3" &>/dev/null && "$common_substr_bin" -n -f "$tmp3" >"$tmp4" && rm -f -- "$tmp3" "$tmp2"
-    else
-        sort "$tmp2" | tee "$tmp3" &>/dev/null && "$common_substr_bin" -n -f "$tmp3" >"$tmp4" && rm -f -- "$tmp3" "$tmp2"
+    if ! awk -F: '{print $NF}' "$POTFILE" >"$tmp2"; then
+        status_error "Common-substring plaintext extraction failed."
+        exit 1
     fi
+    if ! {
+        sort "$tmp2" | tee "$tmp3" &>/dev/null \
+            && "$common_substr_bin" -n -f "$tmp3" >"$tmp4" \
+            && rm -f -- "$tmp3" "$tmp2"
+    }; then
+        status_error "Common-substring helper preprocessing failed."
+        exit 1
+    fi
+    processor_require_file "$tmp4" "Common-substring output" || exit 1
 fi
 
 hashcat_base -a1 "$tmp4" "$tmp4"

--- a/scripts/processors/12-pack-rule.sh
+++ b/scripts/processors/12-pack-rule.sh
@@ -6,27 +6,48 @@ processor_bootstrap
 
 # Temporary Files
 tmp=$(dryrun_tempfile packrule)
-trap 'processor_interrupt "$tmp" analysis.rule' INT TERM
-trap 'processor_cleanup "$tmp" analysis.rule' EXIT
+pack_workdir="${tmp}.work"
+pack_rule_path="$pack_workdir/analysis.rule"
+
+pack_rule_cleanup() {
+    processor_cleanup "$tmp" "$pack_rule_path"
+    if [ -n "$pack_workdir" ] && ! campaign_path_preserved "$pack_rule_path"; then
+        rm -rf -- "$pack_workdir"
+    fi
+}
+
+trap 'processor_interrupt "$tmp" "$pack_rule_path"' INT TERM
+trap pack_rule_cleanup EXIT
 rulegen_path="scripts/extensions/pack-linux/rulegen.py"
 if [ "$MACHINE" == "Mac" ]; then
     rulegen_path="scripts/extensions/pack-mac/rulegen.py"
 fi
+rulegen_absolute_path="$(cd "$(dirname "$rulegen_path")" && pwd)/$(basename "$rulegen_path")"
 
 # Logic
 if dry_run_enabled; then
     dryrun_note "would extract plaintexts from $POTFILE to $tmp"
-    dryrun_note "would run python3 $rulegen_path $tmp"
+    dryrun_note "would run python3 $rulegen_path $tmp in $pack_workdir"
 else
-    cat "$POTFILE" | awk -F: '{print $NF}' | tee "$tmp" &>/dev/null
-    python3 "$rulegen_path" "$tmp"
-    rm -f -- analysis-sorted.word analysis.word analysis-sorted.rule
+    if ! cat "$POTFILE" | awk -F: '{print $NF}' | tee "$tmp" &>/dev/null; then
+        status_error "PACK rule plaintext extraction failed."
+        exit 1
+    fi
+    if ! mkdir -p "$pack_workdir"; then
+        status_error "Unable to create the PACK rule work directory: $pack_workdir"
+        exit 1
+    fi
+    if ! (cd "$pack_workdir" && python3 "$rulegen_absolute_path" "$tmp"); then
+        status_error "PACK rule generation failed."
+        exit 1
+    fi
+    processor_require_file "$pack_rule_path" "PACK rule output" || exit 1
 fi
 
 source scripts/selectors/wordlist.sh
 
-hashcat_base "$WORDLIST" -r analysis.rule $LOOPBACK
+hashcat_base "$WORDLIST" -r "$pack_rule_path" "$LOOPBACK"
 if ! dry_run_enabled; then
-    rm -f -- analysis.rule "$tmp"
+    rm -f -- "$pack_rule_path" "$tmp"
 fi
 echo -e "\nPACK rule processing done\n"

--- a/scripts/processors/13-pack-mask.sh
+++ b/scripts/processors/13-pack-mask.sh
@@ -5,9 +5,9 @@
 processor_bootstrap
 
 # Temporary Files
-tmp=$(dryrun_tempfile packmask)
-tmp2=$(dryrun_tempfile packmask)
-tmp3=$(dryrun_tempfile packmask)
+tmp=$(dryrun_tempfile packmask-1)
+tmp2=$(dryrun_tempfile packmask-2)
+tmp3=$(dryrun_tempfile packmask-3)
 trap 'processor_interrupt "$tmp" "$tmp2" "$tmp3"' INT TERM
 trap 'processor_cleanup "$tmp" "$tmp2" "$tmp3"' EXIT
 
@@ -20,14 +20,30 @@ if dry_run_enabled; then
         dryrun_note "would run python3 statsgen/maskgen to produce $tmp3"
     fi
 else
-    cat "$POTFILE" | awk -F: '{print $NF}' | sort -u | tee "$tmp" &>/dev/null
-    if [ "$MACHINE" == "Mac" ]; then
-        python3 scripts/extensions/pack-mac/statsgen.py "$tmp" -o "$tmp2"
-        python3 scripts/extensions/pack-mac/maskgen.py "$tmp2" --targettime 1000 --optindex -q --pps 14000000000 --minlength=2 -o "$tmp3"
-    else
-        python3 scripts/extensions/pack-linux/statsgen.py "$tmp" -o "$tmp2"
-        python3 scripts/extensions/pack-linux/maskgen.py "$tmp2" --targettime 1000 --optindex -q --pps 14000000000 --minlength=2 -o "$tmp3"
+    if ! cat "$POTFILE" | awk -F: '{print $NF}' | sort -u | tee "$tmp" &>/dev/null; then
+        status_error "PACK mask plaintext extraction failed."
+        exit 1
     fi
+    if [ "$MACHINE" == "Mac" ]; then
+        if ! processor_run python3 scripts/extensions/pack-mac/statsgen.py "$tmp" -o "$tmp2"; then
+            status_error "PACK statistics generation failed."
+            exit 1
+        fi
+        if ! processor_run python3 scripts/extensions/pack-mac/maskgen.py "$tmp2" --targettime 1000 --optindex -q --pps 14000000000 --minlength=2 -o "$tmp3"; then
+            status_error "PACK mask generation failed."
+            exit 1
+        fi
+    else
+        if ! processor_run python3 scripts/extensions/pack-linux/statsgen.py "$tmp" -o "$tmp2"; then
+            status_error "PACK statistics generation failed."
+            exit 1
+        fi
+        if ! processor_run python3 scripts/extensions/pack-linux/maskgen.py "$tmp2" --targettime 1000 --optindex -q --pps 14000000000 --minlength=2 -o "$tmp3"; then
+            status_error "PACK mask generation failed."
+            exit 1
+        fi
+    fi
+    processor_require_file "$tmp3" "PACK mask output" || exit 1
 fi
 
 hashcat_base -a 3 "$tmp3"

--- a/scripts/processors/14-fingerprint.sh
+++ b/scripts/processors/14-fingerprint.sh
@@ -14,8 +14,8 @@ esac
 fingerprint_candidate_max=$((fingerprint_segment_max * 2))
 
 # Temporary Files
-tmp=$(dryrun_tempfile fingerprint)
-tmp2=$(dryrun_tempfile fingerprint)
+tmp=$(dryrun_tempfile fingerprint-1)
+tmp2=$(dryrun_tempfile fingerprint-2)
 trap 'processor_interrupt "$tmp" "$tmp2"' INT TERM
 trap 'processor_cleanup "$tmp" "$tmp2"' EXIT
 
@@ -24,8 +24,11 @@ if dry_run_enabled; then
     dryrun_note "would extract unique plaintexts from $POTFILE to $tmp"
     dryrun_note "would generate fingerprint fragments up to $fingerprint_segment_max chars, producing combinator candidates up to $fingerprint_candidate_max chars"
 else
-    awk -F: '{print $NF}' "$POTFILE" | sort -u >"$tmp"
-    LC_ALL=C awk -v max_len="$fingerprint_segment_max" '
+    if ! awk -F: '{print $NF}' "$POTFILE" | sort -u >"$tmp"; then
+        status_error "Fingerprint plaintext extraction failed."
+        exit 1
+    fi
+    if ! LC_ALL=C awk -v max_len="$fingerprint_segment_max" '
         function rotl(s) { return substr(s, 2) substr(s, 1, 1) }
         function rotr(s) { return substr(s, length(s), 1) substr(s, 1, length(s) - 1) }
         function emit_chunks(s, n,    j) {
@@ -48,7 +51,11 @@ else
                 }
             }
         }
-    ' "$tmp" | sort -u >"$tmp2" && rm -f -- "$tmp"
+    ' "$tmp" | sort -u >"$tmp2" && rm -f -- "$tmp"; then
+        status_error "Fingerprint generation failed."
+        exit 1
+    fi
+    processor_require_file "$tmp2" "Fingerprint output" || exit 1
 fi
 
 hashcat_base -a 1 "$tmp2" "$tmp2"

--- a/scripts/processors/15-multiple-wordlists.sh
+++ b/scripts/processors/15-multiple-wordlists.sh
@@ -13,8 +13,8 @@ source scripts/rules/rules.config
 RULELIST=("$ORTRTS")
 
 # Logic
-hashcat_base $WORDLIST
+hashcat_base "$WORDLIST"
 for RULE in "${RULELIST[@]}"; do
-    hashcat_base $WORDLIST -r $RULE $LOOPBACK
+    hashcat_base "$WORDLIST" -r "$RULE" "$LOOPBACK"
 done
 echo -e "\nMultiple wordlists done\n"

--- a/scripts/processors/16-usernameaspassword.sh
+++ b/scripts/processors/16-usernameaspassword.sh
@@ -17,13 +17,17 @@ trap 'processor_cleanup "$tmp"' EXIT
 if dry_run_enabled; then
     dryrun_note "would extract usernames from $HASHLIST into $tmp"
 else
-    cat $HASHLIST | cut -d '\' -f2 | awk -F: '{print $1}' >$tmp
+    if ! cat "$HASHLIST" | cut -d '\' -f2 | awk -F: '{print $1}' >"$tmp"; then
+        status_error "Username extraction failed."
+        exit 1
+    fi
+    processor_require_file "$tmp" "Username output" || exit 1
 fi
-hashcat_base $tmp
+hashcat_base "$tmp"
 for RULE in "${RULELIST[@]}"; do
-    hashcat_base $tmp -r $RULE $LOOPBACK
+    hashcat_base "$tmp" -r "$RULE" "$LOOPBACK"
 done
 if ! dry_run_enabled; then
-    rm $tmp
+    rm -f -- "$tmp"
 fi
 echo -e "\nUsername as Password processing with rules done\n"

--- a/scripts/processors/17-markov-generator.sh
+++ b/scripts/processors/17-markov-generator.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # Author: crypt0rr - https://github.com/crypt0rr/
 
-RESTART="source scripts/processors/17-markov-generator.sh"
-
 # Requirements
 processor_bootstrap
 if [ "$MACHINE" == "Mac" ]; then
@@ -16,24 +14,27 @@ source scripts/rules/rules.config
 RULELIST=("$rule3" "$rockyou30000" "$ORTRTS" "$fbfull" "$pantag" "$OUTD" "$techtrip2" "$TOXICSP" "$passwordpro" "$d3ad0ne" "$d3adhob0" "$generated2" "$toprules2020" "$hob064" "$leetspeak")
 
 # Temporary Files
-tmp=$(dryrun_tempfile markov)
-tmp2=$(dryrun_tempfile markov)
+tmp=$(dryrun_tempfile markov-1)
+tmp2=$(dryrun_tempfile markov-2)
 trap 'processor_interrupt "$tmp" "$tmp2"' INT TERM
 trap 'processor_cleanup "$tmp" "$tmp2"' EXIT
 
 # Logic
-read -p "Use potfile (p) or wordlist (w): " LIST
-
-if [ "$LIST" == 'p' ]; then
-    LIST=$POTFILE
-elif [ "$LIST" == 'w' ]; then
-    source scripts/selectors/wordlist.sh
-    LIST=$WORDLIST
-else
+while true; do
+    if ! read -r -p "Use potfile (p) or wordlist (w): " LIST; then
+        status_error "Unable to read the Markov source choice."
+        exit 1
+    fi
+    if [ "$LIST" = 'p' ]; then
+        LIST=$POTFILE
+        break
+    elif [ "$LIST" = 'w' ]; then
+        source scripts/selectors/wordlist.sh
+        LIST=$WORDLIST
+        break
+    fi
     echo -e "Try again...\n"
-    $RESTART
-    exit 0
-fi
+done
 
 read -p "Minimum password (length) character limit: " NGRAM
 read -p "Amount of passwords to create: " AMOUNT
@@ -46,32 +47,46 @@ if dry_run_enabled; then
         dryrun_note "would run mkpass-linux with ngram=$NGRAM amount=$AMOUNT into $tmp2"
     fi
 else
-    cat "$LIST" | awk -F: '{print $NF}' | sort -u | tee "$tmp" &>/dev/null
+    if ! cat "$LIST" | awk -F: '{print $NF}' | sort -u | tee "$tmp" &>/dev/null; then
+        status_error "Markov source extraction failed."
+        exit 1
+    fi
     if [ "$MACHINE" == "Mac" ]; then
-        "$mkpass_bin" -infile "$tmp" -ngram "$NGRAM" -m "$AMOUNT" | tee "$tmp2" &>/dev/null && rm -f -- "$tmp"
+        if ! "$mkpass_bin" -infile "$tmp" -ngram "$NGRAM" -m "$AMOUNT" | tee "$tmp2" &>/dev/null; then
+            status_error "Markov helper failed."
+            exit 1
+        fi
     else
-        "$mkpass_bin" -infile "$tmp" -ngram "$NGRAM" -m "$AMOUNT" | tee "$tmp2" &>/dev/null && rm -f -- "$tmp"
+        if ! "$mkpass_bin" -infile "$tmp" -ngram "$NGRAM" -m "$AMOUNT" | tee "$tmp2" &>/dev/null; then
+            status_error "Markov helper failed."
+            exit 1
+        fi
     fi
+    processor_require_file "$tmp2" "Markov output" || exit 1
+    rm -f -- "$tmp"
 fi
 
-read -p "Use rules? (y/n): " USERULES
-
-if [[ $USERULES =~ ^[Yy]$ ]]; then
-    for RULE in "${RULELIST[@]}"; do
-        hashcat_base "$tmp2" -r "$RULE" $LOOPBACK
-    done
-    if ! dry_run_enabled; then
-        rm -f -- "$tmp2"
+while true; do
+    if ! read -r -p "Use rules? (y/n): " USERULES; then
+        status_error "Unable to read the Markov rules choice."
+        exit 1
     fi
-elif [[ $USERULES =~ ^[Nn]$ ]]; then
-    hashcat_base "$tmp2"
-    if ! dry_run_enabled; then
-        rm -f -- "$tmp2"
+    if [[ $USERULES =~ ^[Yy]$ ]]; then
+        for RULE in "${RULELIST[@]}"; do
+            hashcat_base "$tmp2" -r "$RULE" "$LOOPBACK"
+        done
+        if ! dry_run_enabled; then
+            rm -f -- "$tmp2"
+        fi
+        break
+    elif [[ $USERULES =~ ^[Nn]$ ]]; then
+        hashcat_base "$tmp2"
+        if ! dry_run_enabled; then
+            rm -f -- "$tmp2"
+        fi
+        break
     fi
-else
     echo -e "Try again...\n"
-    $RESTART
-    exit 0
-fi
+done
 
 echo -e "\nMarkov-chain processing done\n"

--- a/scripts/processors/18-cewl.sh
+++ b/scripts/processors/18-cewl.sh
@@ -26,7 +26,11 @@ echo -e "\nNOTE: If it takes to long, use CTRL+C to stop where CeWL is currently
 if dry_run_enabled; then
     dryrun_note "would run CeWL against $URL and write $CEWLLIST"
 else
-    "$CEWL" -d "$DEPTH" -m "$LENGTH" -w "$CEWLLIST" "$URL" -u "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+    if ! processor_run "$CEWL" -d "$DEPTH" -m "$LENGTH" -w "$CEWLLIST" "$URL" -u "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"; then
+        status_error "CeWL failed to generate a wordlist."
+        exit 1
+    fi
+    processor_require_file "$CEWLLIST" "CeWL wordlist" || exit 1
 fi
 
-echo -e "\nCeWL created a wordlist named:" $CEWLLIST "\n"
+printf '\nCeWL created a wordlist named: %s\n\n' "$CEWLLIST"

--- a/scripts/processors/19-digitremover.sh
+++ b/scripts/processors/19-digitremover.sh
@@ -17,22 +17,55 @@ trap 'processor_cleanup "$tmp"' EXIT
 if dry_run_enabled; then
     dryrun_note "would generate digit-stripped candidate list from $POTFILE into $tmp"
 else
-    cat $POTFILE | cut -d: -f2- | grep -v '^\$HEX\[' | sed 's/[0-9]//g' | tee $tmp &>/dev/null
-    cat $POTFILE | cut -d: -f2- | grep '^\$HEX\[' | sed "s/\$HEX\[\(.*\)\]/\10a/" | xxd -r -ps | LC_ALL=C sed 's/[0-9]//g' | LC_ALL=C tee -a $tmp &>/dev/null
+    if [ ! -f "$POTFILE" ]; then
+        status_error "Digit-removal source potfile is missing: $POTFILE"
+        exit 1
+    fi
+    if ! cut -d: -f2- "$POTFILE" | awk '!/^\$HEX\[/' | sed 's/[0-9]//g' >"$tmp"; then
+        status_error "Unable to generate digit-removal candidates from the potfile."
+        exit 1
+    fi
+    if ! cut -d: -f2- "$POTFILE" | LC_ALL=C awk '
+        function hex_digit(value) {
+            return index("0123456789abcdef", tolower(value)) - 1
+        }
+        /^\$HEX\[/ {
+            encoded = $0
+            sub(/^\$HEX\[/, "", encoded)
+            sub(/\]$/, "", encoded)
+            if (length(encoded) % 2 != 0 || encoded !~ /^[[:xdigit:]]*$/) {
+                exit 1
+            }
+            decoded = ""
+            for (position = 1; position <= length(encoded); position += 2) {
+                high = hex_digit(substr(encoded, position, 1))
+                low = hex_digit(substr(encoded, position + 1, 1))
+                if (high < 0 || low < 0) {
+                    exit 1
+                }
+                decoded = decoded sprintf("%c", high * 16 + low)
+            }
+            print decoded
+        }
+    ' | LC_ALL=C sed 's/[0-9]//g' >>"$tmp"; then
+        status_error "Unable to decode hexadecimal potfile candidates."
+        exit 1
+    fi
+    processor_require_file "$tmp" "Digit-removal output" || exit 1
 fi
 
 # Logic
-hashcat_base -a6 $tmp -j c '?s?d?d?d?d' --increment
-hashcat_base -a6 $tmp -j c '?d?d?d?d?s' --increment
-hashcat_base -a6 $tmp -j c '?a?a' --increment
-hashcat_base -a6 $tmp '?s?d?d?d?d' --increment
-hashcat_base -a6 $tmp '?d?d?d?d?s' --increment
-hashcat_base -a6 $tmp '?a?a' --increment
+hashcat_base -a6 "$tmp" -j c '?s?d?d?d?d' --increment
+hashcat_base -a6 "$tmp" -j c '?d?d?d?d?s' --increment
+hashcat_base -a6 "$tmp" -j c '?a?a' --increment
+hashcat_base -a6 "$tmp" '?s?d?d?d?d' --increment
+hashcat_base -a6 "$tmp" '?d?d?d?d?s' --increment
+hashcat_base -a6 "$tmp" '?a?a' --increment
 
 for RULE in "${RULELIST[@]}"; do
-    hashcat_base $tmp -r $RULE
+    hashcat_base "$tmp" -r "$RULE"
 done
 if ! dry_run_enabled; then
-    rm $tmp
+    rm -f -- "$tmp"
 fi
 echo -e "\nDigit removal / Hybrid processing done\n"

--- a/scripts/processors/2-light.sh
+++ b/scripts/processors/2-light.sh
@@ -14,6 +14,9 @@ if [[ $MODE = [Ss] ]]; then
     source scripts/selectors/wordlist.sh
 elif [[ $MODE = [Mm] ]]; then
     source scripts/selectors/multiple-wordlist.sh
+else
+    status_error "Invalid wordlist mode '$MODE'. Choose S or M."
+    exit 1
 fi
 
 # Rules
@@ -21,8 +24,8 @@ source scripts/rules/rules.config
 RULELIST=("$rule3" "$rockyou30000" "$ORTRTS" "$fbtop" "$OUTD" "$TOXICSP" "$passwordpro" "$d3ad0ne" "$d3adhob0" "$generated2" "$toprules2020" "$digits1" "$digits2" "$hob064" "$leetspeak" "$toggles1" "$toggles2")
 
 # Logic
-hashcat_base $WORDLIST
+hashcat_base "$WORDLIST"
 for RULE in "${RULELIST[@]}"; do
-    hashcat_base $WORDLIST -r $RULE $LOOPBACK
+    hashcat_base "$WORDLIST" -r "$RULE" "$LOOPBACK"
 done
 echo -e "\nDefault processing with light rules done\n"

--- a/scripts/processors/20-stacker.sh
+++ b/scripts/processors/20-stacker.sh
@@ -21,8 +21,8 @@ source scripts/rules/rules.config
 RULELIST=("$rule3" "$fbtop" "$toprules2020" "$digits1" "$digits2" "$hob064" "$leetspeak" "$toggles1" "$toggles2" "$OUTD")
 
 # Logic
-hashcat_base $WORDLIST -r $stacking58 -r $stacking58 $LOOPBACK
+hashcat_base "$WORDLIST" -r "$stacking58" -r "$stacking58" "$LOOPBACK"
 for RULE in "${RULELIST[@]}"; do
-    hashcat_base $WORDLIST -r $stacking58 -r $RULE $LOOPBACK
+    hashcat_base "$WORDLIST" -r "$stacking58" -r "$RULE" "$LOOPBACK"
 done
 echo -e "\nStacking with light rules done\n"

--- a/scripts/processors/21-custom-brute-force.sh
+++ b/scripts/processors/21-custom-brute-force.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # Author: crypt0rr - https://github.com/crypt0rr/
 
-RESTART="source scripts/processors/21-custom-brute-force.sh"
-
 # Interrupt handling
 trap 'processor_interrupt' INT TERM
 
@@ -10,33 +8,46 @@ trap 'processor_interrupt' INT TERM
 processor_bootstrap
 
 # Logic
-read -p "Heavy lifting? How much chars are we going to brute-force? (1-99): " CHARS
 TARGET=''
-[ -n "$CHARS" ] && [ "$CHARS" -eq "$CHARS" ] 2>/dev/null
-if [ $? -ne 0 ]; then
-    echo $CHARS is not a number.
-    $RESTART
-elif [ "$CHARS" -lt 1 ]; then
-    echo NO!
-    $RESTART
-else
-    COUNT="$CHARS"
-    while [ "$COUNT" -gt 0 ]; do
-        TARGET+="?a"
-        COUNT=$((COUNT - 1))
-    done
-fi
+while true; do
+    if ! read -r -p "Heavy lifting? How much chars are we going to brute-force? (1-99): " CHARS; then
+        status_error "Unable to read the brute-force length."
+        exit 1
+    fi
+    if [[ "$CHARS" =~ ^[0-9]+$ ]] && [ "$CHARS" -ge 1 ]; then
+        COUNT="$CHARS"
+        while [ "$COUNT" -gt 0 ]; do
+            TARGET+="?a"
+            COUNT=$((COUNT - 1))
+        done
+        break
+    fi
+    if [[ "$CHARS" =~ ^[0-9]+$ ]]; then
+        echo "NO!"
+    else
+        printf '%s is not a number.\n' "$CHARS"
+    fi
+    status_error "Enter a positive numeric brute-force length."
+done
 
-read -p "Enable increment? (y/n) " INCREMENT
+while true; do
+    if ! read -r -p "Enable increment? (y/n) " INCREMENT; then
+        status_error "Unable to read the increment choice."
+        exit 1
+    fi
+    case "$INCREMENT" in
+        y)
+            INCREMENT='--increment'
+            break
+            ;;
+        n)
+            INCREMENT=''
+            break
+            ;;
+        *) status_error "Choose y or n for increment." ;;
+    esac
+done
 
-if [ "$INCREMENT" == 'y' ]; then
-    INCREMENT='--increment'
-elif [ "$INCREMENT" == 'n' ]; then
-    INCREMENT=''
-else
-    $RESTART
-fi
-
-hashcat_base -a3 $TARGET $INCREMENT
+hashcat_base -a3 "$TARGET" "$INCREMENT"
 
 echo -e "\nCustom Brute Force Processing Done\n"

--- a/scripts/processors/22-multiple-wordlists-buka.sh
+++ b/scripts/processors/22-multiple-wordlists-buka.sh
@@ -13,8 +13,8 @@ source scripts/rules/rules.config
 RULELIST=("$buka")
 
 # Logic
-hashcat_base $WORDLIST
+hashcat_base "$WORDLIST"
 for RULE in "${RULELIST[@]}"; do
-    hashcat_base $WORDLIST -r $RULE $LOOPBACK
+    hashcat_base "$WORDLIST" -r "$RULE" "$LOOPBACK"
 done
 echo -e "\nMultiple wordlists done\n"

--- a/scripts/processors/3-heavy.sh
+++ b/scripts/processors/3-heavy.sh
@@ -21,8 +21,8 @@ source scripts/rules/rules.config
 RULELIST=("$tenKrules" "$fbfull" "$NSAKEYv2" "$fordyv1" "$pantag" "$OUTD" "$techtrip2" "$williamsuper" "$digits3" "$dive" "$robotmyfavorite")
 
 # Logic
-hashcat_base $WORDLIST
+hashcat_base "$WORDLIST"
 for RULE in "${RULELIST[@]}"; do
-    hashcat_base $WORDLIST -r $RULE $LOOPBACK
+    hashcat_base "$WORDLIST" -r "$RULE" "$LOOPBACK"
 done
 echo -e "\nDefault processing with heavy rules done\n"

--- a/scripts/processors/4-word.sh
+++ b/scripts/processors/4-word.sh
@@ -18,12 +18,16 @@ read -p "Enter a word (e.g. company name): " WORD
 if dry_run_enabled; then
     dryrun_note "would write custom word input to $tmp"
 else
-    echo $WORD >$tmp
+    if ! printf '%s\n' "$WORD" >"$tmp"; then
+        status_error "Unable to write the custom word input."
+        exit 1
+    fi
+    processor_require_file "$tmp" "Custom word input" || exit 1
 fi
 for RULE in "${RULELIST[@]}"; do
-    hashcat_base $tmp -r $RULE $LOOPBACK
+    hashcat_base "$tmp" -r "$RULE" "$LOOPBACK"
 done
 if ! dry_run_enabled; then
-    rm $tmp
+    rm -f -- "$tmp"
 fi
 echo -e "\nWord processing done\n"

--- a/scripts/processors/5-word-bruteforce.sh
+++ b/scripts/processors/5-word-bruteforce.sh
@@ -14,15 +14,19 @@ read -p "Enter a word (e.g. company name): " WORD
 if dry_run_enabled; then
     dryrun_note "would write custom word input to $tmp"
 else
-    echo $WORD >$tmp
+    if ! printf '%s\n' "$WORD" >"$tmp"; then
+        status_error "Unable to write the custom word input."
+        exit 1
+    fi
+    processor_require_file "$tmp" "Custom word input" || exit 1
 fi
-hashcat_base -a6 $tmp '?d?d?d?d?d?d?d?d' -i
-hashcat_base -a6 $tmp '?l?l?l?l?l?l' -i
-hashcat_base -a7 '?d?d?d?d?d?d?d?d' $tmp -i
-hashcat_base -a7 '?l?l?l?l?l?l' $tmp -i
-hashcat_base -a6 $tmp '?a?a?a?a?a' -i
-hashcat_base -a7 '?a?a?a?a?a' $tmp -i
+hashcat_base -a6 "$tmp" '?d?d?d?d?d?d?d?d' -i
+hashcat_base -a6 "$tmp" '?l?l?l?l?l?l' -i
+hashcat_base -a7 '?d?d?d?d?d?d?d?d' "$tmp" -i
+hashcat_base -a7 '?l?l?l?l?l?l' "$tmp" -i
+hashcat_base -a6 "$tmp" '?a?a?a?a?a' -i
+hashcat_base -a7 '?a?a?a?a?a' "$tmp" -i
 if ! dry_run_enabled; then
-    rm $tmp
+    rm -f -- "$tmp"
 fi
 echo -e "\nWord processing done\n"

--- a/scripts/processors/6-hybrid.sh
+++ b/scripts/processors/6-hybrid.sh
@@ -14,13 +14,16 @@ if [[ $MODE = [Ss] ]]; then
     source scripts/selectors/wordlist.sh
 elif [[ $MODE = [Mm] ]]; then
     source scripts/selectors/multiple-wordlist.sh
+else
+    status_error "Invalid wordlist mode '$MODE'. Choose S or M."
+    exit 1
 fi
 
 # Logic
-hashcat_base -a6 $WORDLIST -j c '?s?d?d?d?d' --increment
-hashcat_base -a6 $WORDLIST -j c '?d?d?d?d?s' --increment
-hashcat_base -a6 $WORDLIST -j c '?a?a' --increment
-hashcat_base -a6 $WORDLIST '?s?d?d?d?d' --increment
-hashcat_base -a6 $WORDLIST '?d?d?d?d?s' --increment
-hashcat_base -a6 $WORDLIST '?a?a' --increment
+hashcat_base -a6 "$WORDLIST" -j c '?s?d?d?d?d' --increment
+hashcat_base -a6 "$WORDLIST" -j c '?d?d?d?d?s' --increment
+hashcat_base -a6 "$WORDLIST" -j c '?a?a' --increment
+hashcat_base -a6 "$WORDLIST" '?s?d?d?d?d' --increment
+hashcat_base -a6 "$WORDLIST" '?d?d?d?d?s' --increment
+hashcat_base -a6 "$WORDLIST" '?a?a' --increment
 echo -e "\nHybrid processing done\n"

--- a/scripts/processors/7-toggle.sh
+++ b/scripts/processors/7-toggle.sh
@@ -22,7 +22,7 @@ RULELIST=("$rockyou30000" "$ORTRTS" "$OUTD" "$passwordpro" "$d3ad0ne" "$d3adhob0
 
 # Logic
 for RULE in "${RULELIST[@]}"; do
-    hashcat_base $WORDLIST -r $toggles1 -r $RULE $LOOPBACK
-    hashcat_base $WORDLIST -r $toggles2 -r $RULE $LOOPBACK
+    hashcat_base "$WORDLIST" -r "$toggles1" -r "$RULE" "$LOOPBACK"
+    hashcat_base "$WORDLIST" -r "$toggles2" -r "$RULE" "$LOOPBACK"
 done
 echo -e "\nToggle processing done\n"

--- a/scripts/processors/8-combinator.sh
+++ b/scripts/processors/8-combinator.sh
@@ -9,5 +9,5 @@ processor_bootstrap
 source scripts/selectors/multiple-wordlist.sh
 
 # Logic
-hashcat_base -a1 $WORDLIST $WORDLIST2
+hashcat_base -a1 "$WORDLIST" "$WORDLIST2"
 echo -e "\nCombinator processing done\n"

--- a/scripts/processors/9-iterate.sh
+++ b/scripts/processors/9-iterate.sh
@@ -14,15 +14,20 @@ trap 'processor_interrupt "$tmp"' INT TERM
 trap 'processor_cleanup "$tmp"' EXIT
 
 # Logic
-for RULE in "${RULELIST[@]}"; do
-    if dry_run_enabled; then
-        dryrun_note "would extract unique plaintexts from $POTFILE to $tmp"
-    else
-        cat $POTFILE | awk -F: '{print $NF}' | sort -u | tee $tmp &>/dev/null
+if dry_run_enabled; then
+    dryrun_note "would extract unique plaintexts from $POTFILE to $tmp"
+else
+    if ! awk -F: '{print $NF}' "$POTFILE" | sort -u >"$tmp"; then
+        status_error "Iteration plaintext extraction failed."
+        exit 1
     fi
-    hashcat_base $tmp -r $RULE $LOOPBACK
+    processor_require_file "$tmp" "Iteration output" || exit 1
+fi
+
+for RULE in "${RULELIST[@]}"; do
+    hashcat_base "$tmp" -r "$RULE" "$LOOPBACK"
 done
 if ! dry_run_enabled; then
-    rm $tmp
+    rm -f -- "$tmp"
 fi
 echo -e "\nIteration processing done\n"

--- a/scripts/selectors/multiple-wordlist.sh
+++ b/scripts/selectors/multiple-wordlist.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 # Author: crypt0rr - https://github.com/crypt0rr/
-RESTART="source scripts/selectors/multiple-wordlist.sh"
-
 if ! [[ $START = '8' ]]; then
-    read -e -p "Enter path to a wordlist directory or a single wordlist file: " WORDLIST
-    if [ -d "$WORDLIST" ] && [ -n "$(find "$WORDLIST" -mindepth 1 -print -quit 2>/dev/null)" ]; then
-        echo "Directory" "$WORDLIST" "selected."
-    elif [ -f "$WORDLIST" ]; then
-        echo "Wordlist file" "$WORDLIST" "selected."
-    else
+    while true; do
+        if ! read -e -p "Enter path to a wordlist directory or a single wordlist file: " WORDLIST; then
+            echo "Unable to read a wordlist path."
+            exit 1
+        fi
+        if [ -d "$WORDLIST" ] && [ -n "$(find "$WORDLIST" -mindepth 1 -print -quit 2>/dev/null)" ]; then
+            echo "Directory" "$WORDLIST" "selected."
+            break
+        elif [ -f "$WORDLIST" ]; then
+            echo "Wordlist file" "$WORDLIST" "selected."
+            break
+        fi
         echo "Input must be a non-empty directory or an existing file, try again."
-        $RESTART
-    fi
+    done
 fi
 
 if [[ $START = '8' ]]; then
@@ -21,22 +24,30 @@ if [[ $START = '8' ]]; then
             echo "Wordlist 2:" "$WORDLIST2"
         else
             echo "Wordlist 1 and/or 2 does not exist, edit static configuration in 'hash-cracker.conf'."
-            exit
+            exit 1
         fi
     else
-        read -e -p "Enter full path to first wordlist: " WORDLIST
-        if [ -f "$WORDLIST" ]; then
-            echo "Wordlist" "$WORDLIST" "selected."
-        else
+        while true; do
+            if ! read -e -p "Enter full path to first wordlist: " WORDLIST; then
+                echo "Unable to read the first wordlist path."
+                exit 1
+            fi
+            if [ -f "$WORDLIST" ]; then
+                echo "Wordlist" "$WORDLIST" "selected."
+                break
+            fi
             echo "File does not exist, try again."
-            $RESTART
-        fi
-        read -e -p "Enter full path to second wordlist: " WORDLIST2
-        if [ -f "$WORDLIST2" ]; then
-            echo "Wordlist" "$WORDLIST2" "selected."
-        else
+        done
+        while true; do
+            if ! read -e -p "Enter full path to second wordlist: " WORDLIST2; then
+                echo "Unable to read the second wordlist path."
+                exit 1
+            fi
+            if [ -f "$WORDLIST2" ]; then
+                echo "Wordlist" "$WORDLIST2" "selected."
+                break
+            fi
             echo "File does not exist, try again."
-            $RESTART
-        fi
+        done
     fi
 fi

--- a/scripts/selectors/wordlist.sh
+++ b/scripts/selectors/wordlist.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 # Author: crypt0rr - https://github.com/crypt0rr/
-RESTART="source scripts/selectors/wordlist.sh"
-
 if [[ "$STATICCONFIG" = true ]]; then
     if [ -f "$WORDLIST" ]; then
         echo "Wordlist" "$WORDLIST" "selected."
     else
         echo "Wordlist 1 does not exist, edit static configuration in 'hash-cracker.conf'."
-        exit
+        exit 1
     fi
 else
-    read -e -p "Enter full path to wordlist: " WORDLIST
-    if [ -f "$WORDLIST" ]; then
-        echo "Wordlist" "$WORDLIST" "selected."
-    else
+    while true; do
+        if ! read -e -p "Enter full path to wordlist: " WORDLIST; then
+            echo "Unable to read a wordlist path."
+            exit 1
+        fi
+        if [ -f "$WORDLIST" ]; then
+            echo "Wordlist" "$WORDLIST" "selected."
+            break
+        fi
         echo "File does not exist, try again."
-        $RESTART
-    fi
+    done
 fi

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -74,6 +74,7 @@ def measured_lines(path):
     measured = set()
     heredoc_marker = None
     multiline_awk = False
+    array_literal = False
     continuation = False
 
     for number, line in enumerate(lines, 1):
@@ -89,6 +90,11 @@ def measured_lines(path):
                 multiline_awk = False
             continue
 
+        if array_literal:
+            if stripped == ")":
+                array_literal = False
+            continue
+
         if continuation:
             continuation = line.rstrip().endswith("\\")
             continue
@@ -96,7 +102,20 @@ def measured_lines(path):
         if not stripped or stripped.startswith("#"):
             continue
 
-        if stripped in {"{", "}", "(", ")", "fi", "done", "esac", ";;", "then", "do"}:
+        if stripped in {
+            "{",
+            "}",
+            "(",
+            ")",
+            "fi",
+            "done",
+            "esac",
+            ";;",
+            "then",
+            "do",
+            "if ! {",
+            "}; then",
+        }:
             continue
         if stripped == "else" or stripped.startswith("elif "):
             continue
@@ -106,7 +125,11 @@ def measured_lines(path):
             continue
         if re.match(r"^(function\s+)?[A-Za-z_][A-Za-z0-9_-]*\s*\(\)\s*\{$", stripped):
             continue
+        if re.match(r"^(?:local\s+)?[A-Za-z_][A-Za-z0-9_]*=\($", stripped):
+            array_literal = True
+            continue
         if stripped.startswith(("for ", "while ", "until ", "case ")):
+            continuation = line.rstrip().endswith("\\")
             continue
         if stripped.endswith(")") and not stripped.startswith(
             ("if ", "echo ", "printf ", "return ", "exit ", "source ")

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -13,6 +13,9 @@ export CEWL="$TMP_DIR/cewl"
 
 cat >"$COMMON_SUBSTR_BIN" <<'EOF'
 #!/usr/bin/env bash
+if [ "${COMMON_SUBSTR_FAIL:-0}" = '1' ]; then
+    exit 23
+fi
 printf 'preview\n'
 EOF
 chmod +x "$COMMON_SUBSTR_BIN"
@@ -69,7 +72,15 @@ EOF
 chmod +x "$EDGE_AWK_BIN/awk"
 
 restore_config() {
-    return 0
+    cat >"$CONFIG_PATH" <<EOF
+HASHCAT=("$TMP_DIR/fake-hashcat")
+DEVICE=1
+HASHTYPE=1000
+HASHLIST="$TMP_DIR/input"
+POTFILE="$TMP_DIR/hash-cracker.pot"
+WORDLIST="$TMP_DIR/wordlist.txt"
+WORDLIST2="$TMP_DIR/wordlist2.txt"
+EOF
 }
 
 cleanup() {
@@ -167,7 +178,7 @@ assert_rc_eq 0
 HELPER_INTERRUPT_FILE="$TMP_DIR/helper-interrupt"
 printf 'temporary\n' >"$HELPER_INTERRUPT_FILE"
 run_case helper_interrupt bash -lc "source ./hash-cracker.sh; processor_interrupt '$HELPER_INTERRUPT_FILE'"
-assert_rc_eq 0
+assert_rc_eq 130
 if [ -e "$HELPER_INTERRUPT_FILE" ]; then
     fail_with_log "processor interrupt did not clean its temporary file" "$LAST_LOG"
 fi
@@ -214,6 +225,16 @@ assert_rc_eq 0
 run_case helper_campaign_preserve_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_MANIFEST=fixture; CAMPAIGN_STEP_INDEX=0; CAMPAIGN_STEP_ID=step-001; CAMPAIGN_ACTIVE_COMMAND_INDEX=0; CAMPAIGN_PRESERVED_PATHS=(); python3() { return 1; }; if campaign_command_preserve_inputs '$TMP_DIR/input'; then exit 1; else exit 0; fi"
 assert_rc_eq 0
 
+run_case helper_processor_interrupt_preserve_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_ACTIVE_COMMAND_INDEX=0; CAMPAIGN_INTERRUPT_MARKER='$TMP_DIR/interrupt-preserve-failure'; campaign_command_preserve_inputs() { return 1; }; processor_interrupt '$TMP_DIR/input'"
+assert_rc_eq 1
+assert_contains "Unable to preserve interrupted campaign inputs; cleanup was skipped."
+
+INTERRUPT_MARKER_DIRECTORY="$TMP_DIR/interrupt-marker-directory"
+mkdir -p "$INTERRUPT_MARKER_DIRECTORY"
+run_case helper_processor_interrupt_marker_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_ACTIVE_COMMAND_INDEX=-1; CAMPAIGN_INTERRUPT_MARKER='$INTERRUPT_MARKER_DIRECTORY'; processor_interrupt '$TMP_DIR/input'"
+assert_rc_eq 1
+assert_contains "Unable to preserve interrupted campaign inputs; cleanup was skipped."
+
 run_case helper_campaign_command_finish_noop bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=plan; campaign_command_finish 0 0 0"
 assert_rc_eq 0
 
@@ -226,7 +247,10 @@ assert_rc_eq 0
 run_case helper_run_hashcat_finish_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; source '$REPO_ROOT/scripts/parameters.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_COMMAND_INDEX=0; campaign_command_start() { CAMPAIGN_COMMAND_STATE=running; CAMPAIGN_SESSION_NAME=fixture; CAMPAIGN_RESTORE_FILE='$TMP_DIR/fixture.restore'; CAMPAIGN_RESTORE=0; CAMPAIGN_COMMAND_ARGS_FILE=; return 0; }; campaign_command_record() { return 0; }; campaign_command_finish() { return 1; }; if run_hashcat fixture; then exit 1; else test \"\$?\" -eq 1; fi"
 assert_rc_eq 0
 
-run_case helper_run_hashcat_record_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; source '$REPO_ROOT/scripts/parameters.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_COMMAND_INDEX=0; campaign_command_start() { CAMPAIGN_COMMAND_STATE=running; CAMPAIGN_SESSION_NAME=fixture; CAMPAIGN_RESTORE_FILE='$TMP_DIR/fixture.restore'; CAMPAIGN_RESTORE=0; CAMPAIGN_COMMAND_ARGS_FILE=; return 0; }; campaign_command_record() { return 1; }; if run_hashcat fixture; then exit 1; else test \"\$?\" -eq 1; fi"
+run_case helper_run_hashcat_record_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; source '$REPO_ROOT/scripts/parameters.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_COMMAND_INDEX=-1; CAMPAIGN_COMMAND_FILE=fixture; CAMPAIGN_COMMAND_STATE=running; CAMPAIGN_SESSION_NAME=fixture; CAMPAIGN_RESTORE_FILE='$TMP_DIR/fixture.restore'; CAMPAIGN_RESTORE=0; CAMPAIGN_COMMAND_ARGS_FILE=; campaign_command_start() { return 0; }; campaign_record_command() { return 1; }; if run_hashcat fixture; then exit 1; else test \"\$?\" -eq 1; fi"
+assert_rc_eq 0
+
+run_case helper_run_hashcat_checkpoint_record_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; source '$REPO_ROOT/scripts/parameters.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_COMMAND_INDEX=0; CAMPAIGN_COMMAND_STATE=running; CAMPAIGN_SESSION_NAME=fixture; CAMPAIGN_RESTORE_FILE='$TMP_DIR/fixture.restore'; CAMPAIGN_RESTORE=0; CAMPAIGN_COMMAND_ARGS_FILE=; campaign_command_start() { return 0; }; campaign_command_record() { return 1; }; if run_hashcat fixture; then exit 1; else test \"\$?\" -eq 1; fi"
 assert_rc_eq 0
 
 CAMPAIGN_RESTORE_MISMATCH_FILE="$TMP_DIR/campaign-restore-mismatch"
@@ -239,8 +263,67 @@ printf '%s\0--restore\0' "$TMP_DIR/fake-hashcat" >"$CAMPAIGN_RESTORE_EXISTING_FI
 run_case helper_run_hashcat_existing_restore bash -lc "source '$REPO_ROOT/hash-cracker.sh'; source '$REPO_ROOT/scripts/parameters.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_COMMAND_INDEX=0; campaign_command_start() { CAMPAIGN_COMMAND_STATE=running; CAMPAIGN_COMMAND_ARGS_FILE='$CAMPAIGN_RESTORE_EXISTING_FILE'; CAMPAIGN_RESTORE=1; return 0; }; campaign_command_record() { return 0; }; campaign_command_finish() { return 0; }; run_hashcat fixture"
 assert_rc_eq 0
 
+PROCESSOR_SOURCE_FAILURE="$TMP_DIR/processor-source-failure.sh"
+printf 'exit 7\n' >"$PROCESSOR_SOURCE_FAILURE"
+run_case helper_run_processor_source_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; menu_entries() { printf '1|Fixture|$PROCESSOR_SOURCE_FAILURE\\n'; }; if run_processor 1; then exit 1; else test \"\$?\" -eq 7; fi"
+assert_rc_eq 0
+
+PROCESSOR_RETURN_FAILURE="$TMP_DIR/processor-return-failure.sh"
+printf 'return 7\n' >"$PROCESSOR_RETURN_FAILURE"
+run_case helper_run_processor_return_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; menu_entries() { printf '1|Fixture|$PROCESSOR_RETURN_FAILURE\\n'; }; run_processor 1"
+assert_rc_eq 7
+
+PROCESSOR_STATE_FAILURE="$TMP_DIR/processor-state-failure.sh"
+printf 'PROCESSOR_FAILURE=1\n' >"$PROCESSOR_STATE_FAILURE"
+run_case helper_run_processor_state_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; menu_entries() { printf '1|Fixture|$PROCESSOR_STATE_FAILURE\\n'; }; if run_processor 1; then exit 1; else test \"\$?\" -eq 1; fi"
+assert_rc_eq 0
+
+PROCESSOR_MARKER_FAILURE="$TMP_DIR/processor-marker-failure.sh"
+printf 'exit 7\n' >"$PROCESSOR_MARKER_FAILURE"
+PROCESSOR_MARKER="$TMP_DIR/processor-marker"
+: >"$PROCESSOR_MARKER"
+run_case helper_run_processor_marker_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; menu_entries() { printf '1|Fixture|$PROCESSOR_MARKER_FAILURE\\n'; }; CAMPAIGN_INTERRUPT_MARKER='$PROCESSOR_MARKER'; if run_processor 1; then exit 1; else test \"\$?\" -eq 7; fi"
+assert_rc_eq 0
+
+run_case helper_processor_require_file_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; PROCESSOR_FAILURE=0; if processor_require_file '$TMP_DIR/no-generated-output' Fixture; then exit 1; else test \"\$?\" -eq 1 && test \"\$PROCESSOR_FAILURE\" -eq 1; fi"
+assert_rc_eq 0
+
+CAMPAIGN_RECORD_FILE="$TMP_DIR/campaign-record-failure"
+: >"$CAMPAIGN_RECORD_FILE"
+run_case helper_campaign_record_command_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_CURRENT_STEP=step-001; CAMPAIGN_COMMAND_FILE='$CAMPAIGN_RECORD_FILE'; python3() { return 1; }; if campaign_record_command preview argument; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_campaign_command_record_mktemp_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_MANIFEST=fixture; mktemp() { return 1; }; if campaign_command_record 0 preview argument; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_campaign_command_record_printf_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CAMPAIGN_MODE=execute; CAMPAIGN_MANIFEST=fixture; mktemp() { /usr/bin/mktemp \"\$@\"; }; printf() { return 1; }; if campaign_command_record 0 preview argument; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_campaign_plan_mktemp_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; campaign_jobs_for_source() { printf '1'; }; mktemp() { return 1; }; if run_campaign_plan fixture '$TMP_DIR/plan-mktemp-failure.json'; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_campaign_plan_command_mktemp_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; campaign_jobs_for_source() { printf '1'; }; run_processor() { return 0; }; mktemp() { case \"\${1:-}\" in *campaign-steps.*) /usr/bin/mktemp \"\$@\" ;; *campaign-commands.*) return 1 ;; *) /usr/bin/mktemp \"\$@\" ;; esac; }; if run_campaign_plan fixture '$TMP_DIR/plan-command-mktemp-failure.json'; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+CAMPAIGN_EXECUTE_MKTEMP_MANIFEST="$TMP_DIR/execute-mktemp-failure.json"
+: >"$CAMPAIGN_EXECUTE_MKTEMP_MANIFEST"
+run_case helper_campaign_execute_mktemp_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; campaign_artifact_args() { CAMPAIGN_ARTIFACT_ARGS=(); }; python3() { case \"\${2:-}\" in validate|mark-running) return 0 ;; next) printf '0|step-001|1|Fixture\\n' ;; esac; }; mktemp() { return 1; }; if run_campaign_execute '$CAMPAIGN_EXECUTE_MKTEMP_MANIFEST' Executing; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+
+run_case helper_stats_export_cat_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; STATSEXPORT='$TMP_DIR/helper-cat-export.json'; SESSION_LOG_DISABLED=1; SESSION_LOG_AVAILABLE=0; SESSION_NEW_CRACKS=0; SESSION_NEW_UNIQUE=0; SESSION_GROWTH_BYTES=0; SESSION_POT_LINES_CUR=0; SESSION_POT_UNIQUE_CUR=0; SESSION_POT_BYTES_CUR=0; SESSION_HASHLIST_INPUT_UNIQUE=0; cat() { return 1; }; if export_session_stats_json; then exit 1; else test \"\$?\" -eq 1; fi"
+assert_rc_eq 0
+
+run_case helper_stats_export_mv_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; STATSEXPORT='$TMP_DIR/helper-mv-export.json'; SESSION_LOG_DISABLED=1; SESSION_LOG_AVAILABLE=0; SESSION_NEW_CRACKS=0; SESSION_NEW_UNIQUE=0; SESSION_GROWTH_BYTES=0; SESSION_POT_LINES_CUR=0; SESSION_POT_UNIQUE_CUR=0; SESSION_POT_BYTES_CUR=0; SESSION_HASHLIST_INPUT_UNIQUE=0; mv() { return 1; }; if export_session_stats_json; then exit 1; else test \"\$?\" -eq 1; fi"
+assert_rc_eq 0
+
+run_case helper_session_log_link_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; SESSION_LOG_DIR='$TMP_DIR/helper-link-logs'; SESSION_STATS_LOGFILE=''; SESSION_LOG_DISABLED=0; ln() { return 1; }; init_session_stats_logfile"
+assert_rc_eq 0
+assert_contains "Unable to update latest session log link: $TMP_DIR/helper-link-logs/latest.log"
+
 HELPER_CACHE="$TMP_DIR/helper-cache"
 run_case helper_hashlist_refresh bash -lc "source ./hash-cracker.sh; HASHLIST='$TMP_DIR/input'; POTFILE=/dev/null; SESSION_POT_UNIQUE_CACHE='$HELPER_CACHE'; SESSION_POT_LINES_LAST=0; SESSION_POT_BYTES_LAST=0; SESSION_POT_LINES_BASE=0; SESSION_POT_UNIQUE_BASE=0; SESSION_POT_BYTES_BASE=0; SESSION_POT_UNIQUE_CUR=0; SESSION_HASHLIST_PATH_LAST='$TMP_DIR/old-hashlist'; refresh_session_stats"
+assert_rc_eq 0
+run_case helper_incremental_empty_delta bash -lc "source ./hash-cracker.sh; if update_unique_plaintexts_incremental 0; then exit 0; else exit 1; fi"
 assert_rc_eq 0
 
 run_case helper_missing_pack_files bash -lc "source '$REPO_ROOT/hash-cracker.sh'; cd '$TMP_DIR'; MACHINE=Linux; DRYRUN=' '; if check_job_dependencies 12; then exit 1; else exit 0; fi"
@@ -291,7 +374,7 @@ assert_rc_eq 1
 assert_contains "Missing required configuration file"
 
 INCOMPLETE_CONFIG="$TMP_DIR/incomplete.conf"
-printf 'HASHCAT=(%s)\n' "$TMP_DIR/fake-hashcat" >"$INCOMPLETE_CONFIG"
+printf 'HASHCAT=(%s)\nDEVICE=1\n' "$TMP_DIR/fake-hashcat" >"$INCOMPLETE_CONFIG"
 run_case incomplete_config bash -lc "HASH_CRACKER_CONFIG='$INCOMPLETE_CONFIG' ./hash-cracker.sh --dry-run"
 assert_rc_eq 1
 assert_contains "Missing required setting 'HASHTYPE'"
@@ -704,6 +787,55 @@ assert_contains "| ok      | 0"
 assert_contains "Preset: quick | planned: 2 | completed: 2 | failed: 0 | duration:"
 assert_contains "Preset 'quick' completed."
 
+echo "[smoke] Hashcat arguments preserve paths containing spaces"
+BOUNDARY_DIR="$TMP_DIR/path with spaces"
+BOUNDARY_HASHLIST="$BOUNDARY_DIR/input hashes"
+BOUNDARY_POTFILE="$BOUNDARY_DIR/hash cracker.pot"
+BOUNDARY_WORDLIST="$BOUNDARY_DIR/word list one.txt"
+BOUNDARY_WORDLIST2="$BOUNDARY_DIR/word list two.txt"
+BOUNDARY_ARGS_FILE="$BOUNDARY_DIR/hashcat-args"
+BOUNDARY_HASHCAT="$BOUNDARY_DIR/fake hashcat"
+mkdir -p "$BOUNDARY_DIR"
+printf 'hash:password\n' >"$BOUNDARY_HASHLIST"
+: >"$BOUNDARY_POTFILE"
+printf 'one\n' >"$BOUNDARY_WORDLIST"
+printf 'two\n' >"$BOUNDARY_WORDLIST2"
+cat >"$BOUNDARY_HASHCAT" <<EOF
+#!/usr/bin/env bash
+printf '%s\0' "\$@" >"$BOUNDARY_ARGS_FILE"
+EOF
+chmod +x "$BOUNDARY_HASHCAT"
+cat >"$CONFIG_PATH" <<EOF
+HASHCAT=("$BOUNDARY_HASHCAT")
+DEVICE=1
+HASHTYPE=1000
+HASHLIST="$BOUNDARY_HASHLIST"
+POTFILE="$BOUNDARY_POTFILE"
+WORDLIST="$BOUNDARY_WORDLIST"
+WORDLIST2="$BOUNDARY_WORDLIST2"
+EOF
+run_case boundary_paths bash -lc "printf '8\n0\n' | ./hash-cracker.sh"
+assert_rc_eq 0
+if ! python3 - "$BOUNDARY_ARGS_FILE" "$BOUNDARY_HASHLIST" "--potfile-path=$BOUNDARY_POTFILE" "$BOUNDARY_WORDLIST" "$BOUNDARY_WORDLIST2" <<'PY'; then
+import sys
+
+arguments = open(sys.argv[1], 'rb').read().split(b'\0')[:-1]
+arguments = [value.decode() for value in arguments]
+for expected in sys.argv[2:]:
+    assert expected in arguments, (expected, arguments)
+PY
+    fail_with_log "Hashcat arguments were split at a path boundary" "$LAST_LOG"
+fi
+restore_config
+
+echo "[smoke] explicit stats export failures are visible"
+STATS_EXPORT_BLOCKER="$TMP_DIR/stats-export-blocker"
+printf 'not a directory\n' >"$STATS_EXPORT_BLOCKER"
+STATS_EXPORT_DIRECTORY="$STATS_EXPORT_BLOCKER/export.json"
+run_case stats_export_write_failure bash -lc "printf '0\n' | ./hash-cracker.sh --dry-run --stats-export '$STATS_EXPORT_DIRECTORY'"
+assert_rc_eq 1
+assert_contains "Unable to create output directory: $STATS_EXPORT_BLOCKER"
+
 echo "[smoke] campaign planning captures reproducible command steps"
 CAMPAIGN_PATH="$TMP_DIR/quick-campaign.json"
 run_case campaign_plan bash -lc "./hash-cracker.sh --plan quick --output '$CAMPAIGN_PATH'"
@@ -728,9 +860,34 @@ assert all(
     for command in step["commands"]
 )
 assert manifest["inputs"]["potfile"]["mutable"] is True
+assert manifest["artifacts"]
 PY
     fail_with_log "campaign plan manifest was invalid" "$LAST_LOG"
 fi
+
+CAMPAIGN_ARTIFACT_HASHCAT="$TMP_DIR/campaign-artifact-hashcat"
+cat >"$CAMPAIGN_ARTIFACT_HASHCAT" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$CAMPAIGN_ARTIFACT_HASHCAT"
+CAMPAIGN_ARTIFACT_CONFIG="$TMP_DIR/campaign-artifact.conf"
+cat >"$CAMPAIGN_ARTIFACT_CONFIG" <<EOF
+HASHCAT=($CAMPAIGN_ARTIFACT_HASHCAT)
+DEVICE=1
+HASHTYPE=1000
+HASHLIST=$TMP_DIR/input
+POTFILE=$TMP_DIR/hash-cracker.pot
+WORDLIST=$TMP_DIR/wordlist.txt
+WORDLIST2=$TMP_DIR/wordlist2.txt
+EOF
+CAMPAIGN_ARTIFACT_PATH="$TMP_DIR/artifact-campaign.json"
+run_case campaign_artifact_plan bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_ARTIFACT_CONFIG' ./hash-cracker.sh --plan=1 --output '$CAMPAIGN_ARTIFACT_PATH'"
+assert_rc_eq 0
+printf '# changed after planning\n' >>"$CAMPAIGN_ARTIFACT_HASHCAT"
+run_case campaign_artifact_drift bash -lc "HASH_CRACKER_CONFIG='$CAMPAIGN_ARTIFACT_CONFIG' ./hash-cracker.sh --execute '$CAMPAIGN_ARTIFACT_PATH'"
+assert_rc_eq 1
+assert_contains "campaign artifact changed:"
 
 CAMPAIGN_JOB_PATH="$TMP_DIR/job-campaign.json"
 run_case campaign_plan_equals bash -lc "./hash-cracker.sh --plan=1 --output='$CAMPAIGN_JOB_PATH'"
@@ -995,7 +1152,9 @@ logged = [
 ]
 assert len(logged) >= 2
 preserved_paths = [
-    Path(argument) for argument in logged[0] if argument.startswith("/tmp/hash-cracker-tmp.")
+    Path(argument)
+    for argument in logged[0]
+    if argument.startswith("/tmp/hash-cracker-campaign-")
 ]
 assert preserved_paths
 assert all(not path.exists() for path in preserved_paths)
@@ -1045,8 +1204,14 @@ assert_contains "Preset 'quick' completed."
 if [ ! -s "$PRESET_STATS_EXPORT_PATH" ]; then
     fail_with_log "preset stats export file was not created" "$LAST_LOG"
 fi
-if ! grep -Fq '"release": "v6.6.0 \"Campaign Control\""' "$PRESET_STATS_EXPORT_PATH"; then
-    fail_with_log "preset stats export missing v6.6.0 release marker" "$PRESET_STATS_EXPORT_PATH"
+
+echo "[smoke] helper preprocessing failures propagate"
+run_case common_substring_helper_failure bash -lc "COMMON_SUBSTR_FAIL=1 ./hash-cracker.sh --job 11"
+assert_rc_eq 1
+assert_contains "Common-substring helper preprocessing failed."
+assert_not_contains "Substring processing done"
+if ! grep -Fq '"release": "v6.7.0 \"Execution Confidence\""' "$PRESET_STATS_EXPORT_PATH"; then
+    fail_with_log "preset stats export missing v6.7.0 release marker" "$PRESET_STATS_EXPORT_PATH"
 fi
 
 echo "[smoke] invalid --job selection fails clearly"
@@ -1274,6 +1439,14 @@ run_case processor_20_multiple_mode bash -lc "printf '20\nm\n$TMP_DIR\n0\n' | ./
 assert_rc_eq 0
 assert_contains "Stacking with light rules done"
 
+run_case processor_2_invalid_mode bash -lc "printf '2\nx\n0\n' | ./hash-cracker.sh --dry-run"
+assert_rc_eq 0
+assert_contains "Invalid wordlist mode 'x'. Choose S or M."
+
+run_case processor_6_invalid_mode bash -lc "printf '6\nx\n0\n' | ./hash-cracker.sh --dry-run"
+assert_rc_eq 0
+assert_contains "Invalid wordlist mode 'x'. Choose S or M."
+
 echo "[smoke] processor input validation and alternate paths are exercised"
 cat >"$CONFIG_PATH" <<EOF
 HASHCAT=($TMP_DIR/fake-hashcat)
@@ -1336,6 +1509,22 @@ run_case processor_21_increment bash -lc "printf '21\n2\ny\n0\n' | ./hash-cracke
 assert_rc_eq 0
 assert_contains "--increment"
 
+run_case processor_21_length_eof bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=' '; printf '' | source scripts/processors/21-custom-brute-force.sh"
+assert_rc_eq 1
+assert_contains "Unable to read the brute-force length."
+
+run_case processor_21_increment_eof bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=' '; printf '2\n' | source scripts/processors/21-custom-brute-force.sh"
+assert_rc_eq 1
+assert_contains "Unable to read the increment choice."
+
+run_case processor_17_rules_eof bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=' '; printf 'p\n1\n1\n' | source scripts/processors/17-markov-generator.sh"
+assert_rc_eq 1
+assert_contains "Unable to read the Markov rules choice."
+
+run_case processor_17_source_eof bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=' '; printf '' | source scripts/processors/17-markov-generator.sh"
+assert_rc_eq 1
+assert_contains "Unable to read the Markov source choice."
+
 echo "[smoke] dynamic selectors validate and accept interactive input"
 run_case selector_hashtype bash -lc "printf '1000\n' | bash -c 'STATICCONFIG=false; source scripts/selectors/hashtype.sh'"
 assert_rc_eq 0
@@ -1370,9 +1559,17 @@ assert_rc_eq 0
 assert_contains "File does not exist, try again."
 assert_contains "Wordlist $TMP_DIR/wordlist.txt selected."
 
+run_case selector_wordlist_eof bash -lc "printf '' | bash -c 'STATICCONFIG=false; source scripts/selectors/wordlist.sh'"
+assert_rc_eq 1
+assert_contains "Unable to read a wordlist path."
+
 run_case selector_multiple_wordlist_directory bash -lc "printf '$TMP_DIR\n' | bash -c 'START=15; STATICCONFIG=false; source scripts/selectors/multiple-wordlist.sh'"
 assert_rc_eq 0
 assert_contains "Directory $TMP_DIR selected."
+
+run_case selector_multiple_wordlist_directory_eof bash -lc "printf '' | bash -c 'START=15; STATICCONFIG=false; source scripts/selectors/multiple-wordlist.sh'"
+assert_rc_eq 1
+assert_contains "Unable to read a wordlist path."
 
 run_case selector_multiple_wordlist_invalid_directory bash -lc "printf '$TMP_DIR/not-a-directory\n$TMP_DIR\n' | bash -c 'START=15; STATICCONFIG=false; source scripts/selectors/multiple-wordlist.sh'"
 assert_rc_eq 0
@@ -1396,7 +1593,15 @@ assert_contains "Wordlist $TMP_DIR/wordlist2.txt selected."
 run_case selector_multiple_wordlist_second_invalid bash -lc "printf '$TMP_DIR/wordlist.txt\n$TMP_DIR/not-a-wordlist\n$TMP_DIR/wordlist.txt\n$TMP_DIR/wordlist2.txt\n' | bash -c 'START=8; STATICCONFIG=false; source scripts/selectors/multiple-wordlist.sh'"
 assert_rc_eq 0
 assert_contains "File does not exist, try again."
-assert_contains "Wordlist $TMP_DIR/wordlist2.txt selected."
+assert_contains "Wordlist $TMP_DIR/wordlist.txt selected."
+
+run_case selector_multiple_wordlist_first_eof bash -lc "printf '' | bash -c 'START=8; STATICCONFIG=false; source scripts/selectors/multiple-wordlist.sh'"
+assert_rc_eq 1
+assert_contains "Unable to read the first wordlist path."
+
+run_case selector_multiple_wordlist_second_eof bash -lc "printf '$TMP_DIR/wordlist.txt\n' | bash -c 'START=8; STATICCONFIG=false; source scripts/selectors/multiple-wordlist.sh'"
+assert_rc_eq 1
+assert_contains "Unable to read the second wordlist path."
 
 MISSING_STATIC_WORDLIST="$TMP_DIR/missing-static-wordlist"
 cat >"$CONFIG_PATH" <<EOF
@@ -1649,6 +1854,194 @@ if [ ! -s "$TMP_DIR/normal-cewl-list" ]; then
     fail_with_log "normal CeWL helper did not create its output" "$LAST_LOG"
 fi
 
+FAILING_CEWL="$TMP_DIR/failing-cewl"
+cat >"$FAILING_CEWL" <<'EOF'
+#!/usr/bin/env bash
+exit 23
+EOF
+chmod +x "$FAILING_CEWL"
+run_case processor_18_helper_failure bash -lc "printf '18\nhttps://example.test\n$TMP_DIR/failing-cewl-list\n1\n4\n0\n' | CEWL='$FAILING_CEWL' ./hash-cracker.sh"
+assert_rc_eq 0
+assert_contains "CeWL failed to generate a wordlist."
+assert_contains "Job 18 (CeWL wordlist generator) failed with rc=1"
+assert_not_contains "CeWL created a wordlist named:"
+
+FAILING_COMMON_SUBSTR="$TMP_DIR/failing-common-substr"
+cat >"$FAILING_COMMON_SUBSTR" <<'EOF'
+#!/usr/bin/env bash
+exit 23
+EOF
+chmod +x "$FAILING_COMMON_SUBSTR"
+run_case processor_10_helper_failure bash -lc "COMMON_SUBSTR_BIN='$FAILING_COMMON_SUBSTR' ./hash-cracker.sh --job 10"
+assert_rc_eq 1
+assert_contains "Prefix/suffix helper preprocessing failed."
+run_case processor_11_helper_failure_again bash -lc "COMMON_SUBSTR_BIN='$FAILING_COMMON_SUBSTR' ./hash-cracker.sh --job 11"
+assert_rc_eq 1
+assert_contains "Common-substring helper preprocessing failed."
+
+FAILING_PACK_BIN="$TMP_DIR/failing-pack-bin"
+mkdir -p "$FAILING_PACK_BIN"
+cat >"$FAILING_PACK_BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = '-c' ]; then
+    exit 0
+fi
+exit 23
+EOF
+chmod +x "$FAILING_PACK_BIN/python3"
+run_case processor_12_helper_failure bash -lc "PATH='$FAILING_PACK_BIN:$PATH' ./hash-cracker.sh --job 12"
+assert_rc_eq 1
+assert_contains "PACK rule generation failed."
+run_case processor_12_mac_helper_failure bash -lc "PATH='$PLATFORM_BIN:$FAILING_PACK_BIN:$PATH' ./hash-cracker.sh --job 12"
+assert_rc_eq 1
+assert_contains "PACK rule generation failed."
+run_case processor_13_statsgen_failure bash -lc "PATH='$FAILING_PACK_BIN:$PATH' ./hash-cracker.sh --job 13"
+assert_rc_eq 1
+assert_contains "PACK statistics generation failed."
+run_case processor_13_mac_statsgen_failure bash -lc "PATH='$PLATFORM_BIN:$FAILING_PACK_BIN:$PATH' ./hash-cracker.sh --job 13"
+assert_rc_eq 1
+assert_contains "PACK statistics generation failed."
+
+MASKGEN_FAIL_BIN="$TMP_DIR/maskgen-fail-bin"
+mkdir -p "$MASKGEN_FAIL_BIN"
+cat >"$MASKGEN_FAIL_BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = '-c' ]; then
+    exit 0
+fi
+case "${1:-}" in
+    *statsgen.py)
+        previous=''
+        for argument do
+            if [ "$previous" = '-o' ]; then : >"$argument"; fi
+            previous="$argument"
+        done
+        exit 0
+        ;;
+    *) exit 23 ;;
+esac
+EOF
+chmod +x "$MASKGEN_FAIL_BIN/python3"
+run_case processor_13_maskgen_failure bash -lc "PATH='$MASKGEN_FAIL_BIN:$PATH' ./hash-cracker.sh --job 13"
+assert_rc_eq 1
+assert_contains "PACK mask generation failed."
+run_case processor_13_mac_maskgen_failure bash -lc "PATH='$PLATFORM_BIN:$MASKGEN_FAIL_BIN:$PATH' ./hash-cracker.sh --job 13"
+assert_rc_eq 1
+assert_contains "PACK mask generation failed."
+
+MARKOV_FAIL_BIN="$TMP_DIR/markov-fail-bin"
+mkdir -p "$MARKOV_FAIL_BIN"
+cat >"$MARKOV_FAIL_BIN/mkpass" <<'EOF'
+#!/usr/bin/env bash
+exit 23
+EOF
+chmod +x "$MARKOV_FAIL_BIN/mkpass"
+run_case processor_17_helper_failure bash -lc "printf '17\np\n1\n1\nn\n0\n' | MKPASS_BIN='$MARKOV_FAIL_BIN/mkpass' ./hash-cracker.sh"
+assert_rc_eq 0
+assert_contains "Markov helper failed."
+assert_contains "Job 17 (Markov-chain passwords generator) failed with rc=1"
+run_case processor_17_mac_helper_failure bash -lc "printf '17\np\n1\n1\nn\n0\n' | PATH='$PLATFORM_BIN:$PATH' MKPASS_BIN='$MARKOV_FAIL_BIN/mkpass' ./hash-cracker.sh"
+assert_rc_eq 0
+assert_contains "Markov helper failed."
+
+BROKEN_POTFILE="$TMP_DIR/broken-potfile"
+mkdir -p "$BROKEN_POTFILE"
+cat >"$CONFIG_PATH" <<EOF
+HASHCAT=($TMP_DIR/fake-hashcat)
+DEVICE=1
+HASHTYPE=1000
+HASHLIST=$TMP_DIR/input
+POTFILE=$BROKEN_POTFILE
+WORDLIST=$TMP_DIR/wordlist.txt
+WORDLIST2=$TMP_DIR/wordlist2.txt
+EOF
+run_case processor_14_extraction_failure bash -lc "./hash-cracker.sh --job 14"
+assert_rc_eq 1
+assert_contains "Fingerprint plaintext extraction failed."
+
+run_case processor_9_extraction_failure bash -lc "./hash-cracker.sh --job 9"
+assert_rc_eq 1
+assert_contains "Iteration plaintext extraction failed."
+run_case processor_10_extraction_failure bash -lc "./hash-cracker.sh --job 10"
+assert_rc_eq 1
+assert_contains "Prefix/suffix plaintext extraction failed."
+run_case processor_11_extraction_failure bash -lc "./hash-cracker.sh --job 11"
+assert_rc_eq 1
+assert_contains "Common-substring plaintext extraction failed."
+run_case processor_12_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 12"
+assert_rc_eq 1
+assert_contains "PACK rule plaintext extraction failed."
+run_case processor_13_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 13"
+assert_rc_eq 1
+assert_contains "PACK mask plaintext extraction failed."
+run_case processor_17_extraction_failure bash -lc "printf '17\np\n1\n1\n0\n' | ./hash-cracker.sh"
+assert_rc_eq 0
+assert_contains "Markov source extraction failed."
+
+BROKEN_HASHLIST="$TMP_DIR/broken-hashlist"
+mkdir -p "$BROKEN_HASHLIST"
+cat >"$CONFIG_PATH" <<EOF
+HASHCAT=($TMP_DIR/fake-hashcat)
+DEVICE=1
+HASHTYPE=1000
+HASHLIST=$BROKEN_HASHLIST
+POTFILE=$TMP_DIR/hash-cracker.pot
+WORDLIST=$TMP_DIR/wordlist.txt
+WORDLIST2=$TMP_DIR/wordlist2.txt
+EOF
+run_case processor_16_extraction_failure bash -lc "./hash-cracker.sh --job 16"
+assert_rc_eq 1
+assert_contains "Username extraction failed."
+
+cat >"$CONFIG_PATH" <<EOF
+HASHCAT=($TMP_DIR/fake-hashcat)
+DEVICE=1
+HASHTYPE=1000
+HASHLIST=$TMP_DIR/input
+POTFILE=$BROKEN_POTFILE
+WORDLIST=$TMP_DIR/wordlist.txt
+WORDLIST2=$TMP_DIR/wordlist2.txt
+EOF
+run_case processor_19_missing_potfile_failure bash -lc "./hash-cracker.sh --job 19"
+assert_rc_eq 1
+assert_contains "Digit-removal source potfile is missing"
+
+printf 'hash:$HEX[zz]\n' >"$TMP_DIR/hash-cracker.pot"
+restore_config
+run_case processor_19_malformed_hex bash -lc "./hash-cracker.sh --job 19"
+assert_rc_eq 1
+assert_contains "Unable to decode hexadecimal potfile candidates."
+
+restore_config
+printf 'hash:password\n' >"$TMP_DIR/hash-cracker.pot"
+PACK_WORKDIR_TMP="$TMP_DIR/pack-workdir"
+PACK_WORKDIR_BLOCKER="$PACK_WORKDIR_TMP.work"
+printf 'not a directory\n' >"$PACK_WORKDIR_BLOCKER"
+run_case processor_12_workdir_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; dryrun_tempfile() { printf '$PACK_WORKDIR_TMP'; }; source scripts/processors/12-pack-rule.sh"
+assert_rc_eq 1
+assert_contains "Unable to create the PACK rule work directory: $PACK_WORKDIR_BLOCKER"
+
+FINGERPRINT_GENERATION_BLOCKER="$TMP_DIR/fingerprint-generation-blocker"
+printf 'not a directory\n' >"$FINGERPRINT_GENERATION_BLOCKER"
+run_case processor_14_generation_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; dryrun_tempfile() { case \"\$1\" in fingerprint-1) printf '$TMP_DIR/fingerprint-generation-input' ;; *) printf '$FINGERPRINT_GENERATION_BLOCKER/output' ;; esac; }; source scripts/processors/14-fingerprint.sh"
+assert_rc_eq 1
+assert_contains "Fingerprint generation failed."
+
+DIGIT_OUTPUT_BLOCKER="$TMP_DIR/digit-output-blocker"
+printf 'not a directory\n' >"$DIGIT_OUTPUT_BLOCKER"
+run_case processor_19_generation_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; dryrun_tempfile() { printf '$DIGIT_OUTPUT_BLOCKER/output'; }; source scripts/processors/19-digitremover.sh"
+assert_rc_eq 1
+assert_contains "Unable to generate digit-removal candidates from the potfile."
+
+WRITE_FAILURE_DIR="$TMP_DIR/write-failure"
+mkdir -p "$WRITE_FAILURE_DIR"
+run_case processor_4_write_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; dryrun_tempfile() { printf '$WRITE_FAILURE_DIR'; }; printf 'Acme\\n' | (source scripts/processors/4-word.sh)"
+assert_rc_eq 1
+assert_contains "Unable to write the custom word input."
+run_case processor_5_write_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; dryrun_tempfile() { printf '$WRITE_FAILURE_DIR'; }; printf 'Acme\\n' | (source scripts/processors/5-word-bruteforce.sh)"
+assert_rc_eq 1
+assert_contains "Unable to write the custom word input."
+
 printf 'hash:pass123\nhash:\$HEX[616263313233]\n' >"$TMP_DIR/hash-cracker.pot"
 run_case processor_19_normal bash -lc "./hash-cracker.sh --job 19"
 assert_rc_eq 0
@@ -1816,6 +2209,74 @@ fi
 if ! grep -Fq 'ordinary history line' "$MALFORMED_EXPORT"; then
     fail_with_log "stats export omitted rotated log entries" "$MALFORMED_EXPORT"
 fi
+
+restore_config
+STATS_EXPORT_TARGET_DIR="$TMP_DIR/stats-export-target"
+mkdir -p "$STATS_EXPORT_TARGET_DIR"
+run_case stats_export_replace_failure bash -lc "./hash-cracker.sh --job 1 --stats-export '$STATS_EXPORT_TARGET_DIR'"
+assert_rc_eq 1
+assert_contains "Unable to replace stats export: $STATS_EXPORT_TARGET_DIR"
+
+FINAL_STATS_EXPORT="$TMP_DIR/final-stats-export.json"
+FINAL_EXPORT_HASHCAT="$TMP_DIR/final-export-hashcat"
+cat >"$FINAL_EXPORT_HASHCAT" <<EOF
+#!/usr/bin/env bash
+rm -f -- "$FINAL_STATS_EXPORT"
+mkdir -p "$FINAL_STATS_EXPORT"
+EOF
+chmod +x "$FINAL_EXPORT_HASHCAT"
+cat >"$CONFIG_PATH" <<EOF
+HASHCAT=($FINAL_EXPORT_HASHCAT)
+DEVICE=1
+HASHTYPE=1000
+HASHLIST=$TMP_DIR/input
+POTFILE=$TMP_DIR/hash-cracker.pot
+WORDLIST=$TMP_DIR/wordlist.txt
+WORDLIST2=$TMP_DIR/wordlist2.txt
+EOF
+run_case stats_export_final_replace_failure bash -lc "./hash-cracker.sh --job 1 --stats-export '$FINAL_STATS_EXPORT'"
+assert_rc_eq 1
+assert_contains "Unable to replace stats export: $FINAL_STATS_EXPORT"
+
+rm -rf -- "$FINAL_STATS_EXPORT"
+CAMPAIGN_STATS_EXPORT_PATH="$TMP_DIR/stats-export-campaign.json"
+run_case campaign_stats_export_plan bash -lc "./hash-cracker.sh --plan 1 --output '$CAMPAIGN_STATS_EXPORT_PATH'"
+assert_rc_eq 0
+run_case campaign_stats_export_failure bash -lc "./hash-cracker.sh --execute '$CAMPAIGN_STATS_EXPORT_PATH' --stats-export '$FINAL_STATS_EXPORT'"
+assert_rc_eq 1
+assert_contains "Unable to replace stats export: $FINAL_STATS_EXPORT"
+
+rm -rf -- "$FINAL_STATS_EXPORT"
+run_case preset_stats_export_final_replace_failure bash -lc "./hash-cracker.sh --preset quick --stats-export '$FINAL_STATS_EXPORT'"
+assert_rc_eq 1
+assert_contains "Unable to replace stats export: $FINAL_STATS_EXPORT"
+
+PRESET_INITIAL_EXPORT_DIRECTORY="$TMP_DIR/preset-initial-export-directory"
+mkdir -p "$PRESET_INITIAL_EXPORT_DIRECTORY"
+run_case preset_stats_export_initial_replace_failure bash -lc "./hash-cracker.sh --preset quick --stats-export '$PRESET_INITIAL_EXPORT_DIRECTORY'"
+assert_rc_eq 1
+assert_contains "Unable to replace stats export: $PRESET_INITIAL_EXPORT_DIRECTORY"
+
+restore_config
+LOG_DIR_BLOCKER="$TMP_DIR/log-dir-blocker"
+printf 'not a directory\n' >"$LOG_DIR_BLOCKER"
+run_case session_log_directory_failure bash -lc "SESSION_LOG_DIR='$LOG_DIR_BLOCKER' ./hash-cracker.sh --job 1"
+assert_rc_eq 0
+assert_contains "Unable to create session log directory: $LOG_DIR_BLOCKER"
+
+CUSTOM_LOG_PARENT_BLOCKER="$TMP_DIR/custom-log-parent-blocker"
+printf 'not a directory\n' >"$CUSTOM_LOG_PARENT_BLOCKER"
+run_case custom_session_log_directory_failure bash -lc "SESSION_STATS_LOGFILE='$CUSTOM_LOG_PARENT_BLOCKER/session.log' ./hash-cracker.sh --job 1"
+assert_rc_eq 0
+assert_contains "Unable to create session log directory: $CUSTOM_LOG_PARENT_BLOCKER"
+
+APPEND_LOG_DIRECTORY="$TMP_DIR/append-log-directory"
+mkdir -p "$APPEND_LOG_DIRECTORY"
+run_case session_log_append_failure bash -lc "printf '99\\n0\\n' | SESSION_STATS_LOGFILE='$APPEND_LOG_DIRECTORY' ./hash-cracker.sh --dry-run"
+assert_rc_eq 0
+assert_contains "Unable to append session stats log: $APPEND_LOG_DIRECTORY"
+assert_contains "Session logging"
+assert_contains "unavailable"
 
 echo "[smoke] dependency failure is reported by self-test"
 MISSING_COMMON_SUBSTR="$TMP_DIR/missing-common-substr"

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Direct contract tests for campaign manifest and command state handling."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CAMPAIGN_PATH = REPO_ROOT / "scripts" / "campaign.py"
+SPEC = importlib.util.spec_from_file_location("campaign", CAMPAIGN_PATH)
+assert SPEC and SPEC.loader
+campaign = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(campaign)
+
+
+class CampaignContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.config = self.root / "hash-cracker.conf"
+        self.hashlist = self.root / "hashes"
+        self.potfile = self.root / "hash-cracker.pot"
+        self.wordlist = self.root / "wordlist.txt"
+        self.wordlist2 = self.root / "wordlist2.txt"
+        self.hashcat = self.root / "hashcat"
+        self.artifact = self.root / "processor.sh"
+        for path, content in (
+            (self.config, "HASHCAT=hashcat\n"),
+            (self.hashlist, "hash:password\n"),
+            (self.potfile, ""),
+            (self.wordlist, "password\n"),
+            (self.wordlist2, "welcome\n"),
+            (self.hashcat, "#!/bin/sh\nexit 0\n"),
+            (self.artifact, "#!/bin/sh\nexit 0\n"),
+        ):
+            path.write_text(content, encoding="utf-8")
+        self.steps = self.root / "steps"
+        self.commands = self.root / "commands"
+        self.steps.write_text(
+            "step-001\t1\tFixture\tscripts/processors/1-bruteforce.sh\n",
+            encoding="utf-8",
+        )
+        self.commands.write_text(
+            f"step-001\t{self.hashcat} --bitmap-max=24 -d 1 "
+            f"--potfile-path={self.potfile} -m1000 {self.hashlist}\n",
+            encoding="utf-8",
+        )
+        self.manifest = self.root / "campaign.json"
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def create_args(self, output: Path | None = None) -> argparse.Namespace:
+        return argparse.Namespace(
+            output=str(output or self.manifest),
+            name="fixture",
+            kind="job",
+            release="test",
+            steps_file=str(self.steps),
+            commands_file=str(self.commands),
+            config=str(self.config),
+            hashlist=str(self.hashlist),
+            potfile=str(self.potfile),
+            wordlist=str(self.wordlist),
+            wordlist2=str(self.wordlist2),
+            hashcat=str(self.hashcat),
+            hashtype="1000",
+            machine="Linux",
+            kernel=" ",
+            loopback=" ",
+            hwmon=" ",
+            showcracked=" ",
+            artifact=[str(self.artifact)],
+        )
+
+    def test_manifest_records_artifact_fingerprints(self) -> None:
+        args = self.create_args()
+
+        campaign.create_manifest(args)
+
+        manifest = json.loads(self.manifest.read_text(encoding="utf-8"))
+        artifacts = {item["path"]: item["sha256"] for item in manifest["artifacts"]}
+        expected_digest = hashlib.sha256(self.artifact.read_bytes()).hexdigest()
+        self.assertEqual(artifacts[str(self.artifact.resolve())], expected_digest)
+
+    def test_validation_rejects_changed_artifact(self) -> None:
+        args = self.create_args()
+        campaign.create_manifest(args)
+        campaign.validate_manifest(
+            argparse.Namespace(**vars(args), manifest=str(self.manifest))
+        )
+
+        self.artifact.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        with self.assertRaisesRegex(campaign.CampaignError, "campaign artifact changed"):
+            campaign.validate_manifest(
+                argparse.Namespace(**vars(args), manifest=str(self.manifest))
+            )
+
+    def test_validation_rejects_changed_configuration(self) -> None:
+        args = self.create_args()
+        campaign.create_manifest(args)
+        self.config.write_text("HASHCAT=changed\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(campaign.CampaignError, "campaign input changed for config"):
+            campaign.validate_manifest(
+                argparse.Namespace(**vars(args), manifest=str(self.manifest))
+            )
+
+    def test_plan_rejects_protected_output_path(self) -> None:
+        args = self.create_args(output=self.hashlist)
+
+        with self.assertRaisesRegex(campaign.CampaignError, "conflicts with protected path"):
+            campaign.create_manifest(args)
+
+    def test_validation_allows_legacy_manifest_without_artifacts(self) -> None:
+        args = self.create_args()
+        campaign.create_manifest(args)
+        manifest = json.loads(self.manifest.read_text(encoding="utf-8"))
+        del manifest["artifacts"]
+        self.manifest.write_text(json.dumps(manifest), encoding="utf-8")
+
+        campaign.validate_manifest(
+            argparse.Namespace(**vars(args), manifest=str(self.manifest))
+        )
+
+    def test_command_record_allows_only_campaign_generated_flags_to_differ(self) -> None:
+        args = self.create_args()
+        campaign.create_manifest(args)
+        record_args = argparse.Namespace(
+            manifest=str(self.manifest),
+            index=0,
+            step_id="step-001",
+            command_index=0,
+            preview=(
+                f"{self.hashcat} --bitmap-max=24 -d 1 "
+                f"--potfile-path={self.potfile} -m1000 {self.hashlist} "
+                "--session=fixture --restore-file-path=/tmp/fixture.restore --restore"
+            ),
+        )
+
+        campaign.record_command(record_args)
+        manifest = json.loads(self.manifest.read_text(encoding="utf-8"))
+        self.assertEqual(
+            manifest["steps"][0]["commands"][0]["executed_argv"][-1], "--restore"
+        )
+
+    def test_command_record_rejects_processor_argument_drift(self) -> None:
+        args = self.create_args()
+        campaign.create_manifest(args)
+        record_args = argparse.Namespace(
+            manifest=str(self.manifest),
+            index=0,
+            step_id="step-001",
+            command_index=0,
+            preview=(
+                f"{self.hashcat} --bitmap-max=24 -d 1 "
+                f"--potfile-path={self.potfile} -m1000 {self.hashlist} --changed"
+            ),
+        )
+
+        with self.assertRaisesRegex(campaign.CampaignError, "command changed"):
+            campaign.record_command(record_args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Added isolated deterministic smoke fixtures so tests never depend on developer-local configuration, GPU hardware, real Hashcat execution, network access, or system-installed optional helpers.
- Expanded dry-run and fake-dependency coverage to reach all 22 processors, with direct campaign contract tests.
- Added executable-line and function coverage reporting with a no-regression baseline ratchet and CI artifacts.
- Hardened argument handling, failure propagation, session logging, stats exports, potfile rotation handling, and campaign execution-artifact validation.
- Documented the v6.7.0 "Execution Confidence" release identity and the supported trust and concurrency assumptions.

## Validation

- `make test`
- `make lint`
- Shell formatting check
- Bash syntax validation
- Python syntax validation
- `COVERAGE_DIR=/var/tmp/hash-cracker-v6.7.0-coverage make coverage`
- Coverage result: 100.00% executable-line coverage and 100.00% function coverage; baseline satisfied