### PR TITLE
Use Node.js 24-compatible GitHub Actions

### DIFF
--- a/.github/workflows/shell-quality.yml
+++ b/.github/workflows/shell-quality.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
 
@@ -59,10 +59,10 @@ jobs:
       COVERAGE_TMP_ROOT: /var/tmp
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
 
@@ -73,7 +73,7 @@ jobs:
         run: make coverage-python
 
       - name: Upload Bash coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bash-coverage
           path: |
@@ -83,7 +83,7 @@ jobs:
             coverage/line-percent.txt
 
       - name: Upload Python coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-coverage
           path: coverage/python/

--- a/VERSION.md
+++ b/VERSION.md
@@ -11,6 +11,7 @@
 
 - Pinned GitHub Actions to immutable commit references for repository policy compliance.
 - Made CI lint and format tool installation versioned and checksum-verified.
+- Updated pinned GitHub Actions to Node.js 24-compatible releases.
 
 ## v6.7.0 - Execution Confidence
 


### PR DESCRIPTION
## What changed

- Update the pinned `actions/checkout`, `actions/setup-python`, and `actions/upload-artifact` references to Node.js 24-compatible releases.
- Keep all action references pinned to immutable full-length commit SHAs.
- Record the maintenance update in the Unreleased version log.

## Why

The successful CI run for PR #60 reported non-blocking Node.js 20 deprecation warnings because the pinned action releases targeted Node.js 20. These updates remove that warning while preserving the repository's SHA-pinning policy.

## Validation

- `make test` passed.
- `make lint` passed.
- Workflow YAML parsing passed.
- All action references remain full-length SHA-pinned.
- Each pinned action declares `node24`.
- Bash syntax and `git diff --check` passed.

This is maintainer CI work only and does not change the runtime release version.
