### PR TITLE
Document audit artifact handling

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,96 @@
+# Audit artifacts
+
+This document defines the operational meaning and handling expectations for the
+session logs and JSON statistics exports produced by `hash-cracker`.
+
+These files are local audit artifacts. They are useful for reconstructing what
+the CLI reported during a run, but they are not a compliance record and are not
+tamper-evident, signed, encrypted, or centrally collected by the tool.
+
+## Artifact lifecycle
+
+### Session logs
+
+Unless logging is disabled or an explicit path is configured, each invocation
+creates one file under `logs/`:
+
+```text
+logs/session-YYYYmmdd-HHMMSS-PID.log
+```
+
+The CLI appends timestamped session-stat lines to the active file. For an
+auto-created log, `logs/latest.log` is a convenience symlink to that file. The
+symlink is not a second copy of the evidence and is not included when an
+`all`-scope JSON export reads the `session-*.log` history.
+
+Retention applies only to auto-created `session-*.log` files:
+
+- The default `--session-log-keep 0` keeps all auto-created logs.
+- `--session-log-keep N` keeps the most recent `N` auto-created logs when a new
+  session starts.
+- An explicit `SESSION_STATS_LOGFILE` is not pruned by this setting.
+- `--no-session-log` disables file logging. The dashboard still reports that
+  logging is disabled, and JSON exports record `logging.enabled` as `false`.
+
+If the CLI cannot create, link, or append a session log, it reports the problem
+as a warning and continues. Treat the resulting run as having incomplete audit
+evidence; a successful cracking command does not prove that a complete log was
+written.
+
+### JSON statistics exports
+
+`--stats-export PATH` writes the current statistics to `PATH` on each refresh
+cycle. The export includes the release, hash type, input paths, session delta,
+potfile totals, logging state, and an explicit `schema_version` field. The
+current schema version is `"1"`.
+
+The default `--stats-export-scope latest` writes the current snapshot and an
+empty `history` array. `--stats-export-scope all` additionally parses regular
+`session-*.log` files in the configured session-log directory (default
+`logs/`), in sorted order, and places their entries in `history`. The parser
+preserves ordinary or malformed log lines as message entries so that an export
+does not silently discard source text.
+
+Exports are written through a temporary file and replacement step. Failure to
+create the parent directory, write the temporary file, or replace the target is
+reported as an error and makes the command fail. A partially written JSON file
+is not treated as a successful export.
+
+## Integrity and limitations
+
+The artifacts are observations made by a local process, not an independent
+proof of execution. In particular:
+
+- Anyone who can write the files can alter or delete them; the CLI does not
+  generate signatures, checksums, or an append-only store.
+- The JSON contains counters and paths, not a copy of the hashlist, potfile,
+  Hashcat output, or command transcript.
+- A disabled or unavailable session log, process interruption, filesystem
+  failure, or later pruning can leave the record incomplete.
+- The `all` history is derived from whatever matching log files are present at
+  export time. It is not a server-side or immutable event stream.
+- The artifacts can reveal local paths, hash types, run metadata, and messages
+  imported from session-log files. Handle them as sensitive local data.
+
+The policy assumes the normal single-writer workflow. Concurrent executions
+against one campaign manifest are not supported.
+
+## Preservation guidance
+
+If a run needs to be retained for review:
+
+1. Copy the active session log and the relevant JSON export before cleanup or
+   retention pruning removes them.
+2. Preserve the files in storage with access controls appropriate to the
+   hashes, paths, and operational metadata they contain.
+3. Record the run context separately when needed, including the configuration
+   revision, input-set identity, and Hashcat/tool versions. Do not copy secrets
+   from the trusted local configuration into an audit report unnecessarily.
+4. Generate and store an external checksum or signature if tamper evidence is
+   required by the operating process.
+5. Mark the record as incomplete when logging was disabled, unavailable, or an
+   export failed. `--session-log-keep` is a convenience cleanup control, not an
+   archival or retention policy.
+
+Downstream consumers should inspect `schema_version` and tolerate additional
+fields. A future incompatible export shape should use a new schema version.

--- a/README.md
+++ b/README.md
@@ -313,7 +313,8 @@ When the tool starts successfully, it opens an interactive menu with these optio
 - Session logs and requested JSON exports are local audit artifacts. JSON export write failures are fatal; default session-log failures are reported as warnings so a cracking run is not mistaken for a missing audit record.
 - Exported JSON includes a top-level `"schema_version"` for stable downstream parsing.
 - With `--stats-export-scope latest` (default), JSON contains the latest snapshot only.
-- With `--stats-export-scope all`, JSON also includes parsed history from `logs/session-*.log`.
+- With `--stats-export-scope all`, JSON also includes parsed history from `session-*.log` files in the configured session-log directory.
+- See [Audit artifacts](AUDIT.md) for integrity limitations, retention behavior, and preservation guidance.
 
 ## Example Hashes
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -6,6 +6,7 @@
 
 - Added an independent Python campaign line-coverage report and baseline ratchet.
 - Added a manual workflow trigger and explicit ShellCheck/shfmt version verification for maintainer CI.
+- Added an operational audit-artifact policy for session logs and JSON statistics exports.
 
 ### Changed
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -607,6 +607,26 @@ assert_rc_eq 0
 if [ "$(find "$RETENTION_LOG_DIR" -maxdepth 1 -type f -name 'session-*.log' | wc -l | tr -d '[:space:]')" -ne 1 ]; then
     fail_with_log "session log retention did not keep one log" "$LAST_LOG"
 fi
+if [ ! -L "$RETENTION_LOG_DIR/latest.log" ]; then
+    fail_with_log "auto-created session logs did not update latest.log" "$LAST_LOG"
+fi
+RETENTION_LATEST_TARGET="$(readlink "$RETENTION_LOG_DIR/latest.log")"
+if [ ! -f "$RETENTION_LOG_DIR/$RETENTION_LATEST_TARGET" ]; then
+    fail_with_log "latest.log does not point to the active session log" "$LAST_LOG"
+fi
+
+EXPLICIT_RETENTION_DIR="$TMP_DIR/explicit-retention-logs"
+EXPLICIT_RETENTION_LOG="$TMP_DIR/explicit-retention.log"
+mkdir -p "$EXPLICIT_RETENTION_DIR"
+touch "$EXPLICIT_RETENTION_DIR/session-20200101-000000-1.log" "$EXPLICIT_RETENTION_DIR/session-20200102-000000-2.log"
+run_case explicit_session_log_retention bash -lc "printf '0\n' | SESSION_LOG_DIR='$EXPLICIT_RETENTION_DIR' SESSION_STATS_LOGFILE='$EXPLICIT_RETENTION_LOG' ./hash-cracker.sh --dry-run --session-log-keep 1"
+assert_rc_eq 0
+if [ "$(find "$EXPLICIT_RETENTION_DIR" -maxdepth 1 -type f -name 'session-*.log' | wc -l | tr -d '[:space:]')" -ne 2 ]; then
+    fail_with_log "explicit session log path was unexpectedly pruned" "$LAST_LOG"
+fi
+if [ -L "$EXPLICIT_RETENTION_DIR/latest.log" ]; then
+    fail_with_log "explicit session log path unexpectedly updated latest.log" "$LAST_LOG"
+fi
 
 run_case session_log_retention_zero bash -lc "printf '0\n' | ./hash-cracker.sh --dry-run --session-log-keep 0"
 assert_rc_eq 0


### PR DESCRIPTION
## What changed

- Add `AUDIT.md` describing session-log and JSON-export lifecycle, retention behavior, integrity limitations, and preservation guidance.
- Link the policy from the runtime-status documentation and record it in `VERSION.md` under Unreleased.
- Extend smoke coverage for `latest.log` creation and the boundary that explicit session-log paths are not pruned by auto-log retention.

## Why

The CLI already emits local session logs and JSON statistics exports, but their operational guarantees and limitations were spread across runtime documentation. This makes the handling expectations durable and explicit without implying that the files are signed, tamper-evident, or a compliance record.

## Validation

- `make test-smoke`
- `make test-campaign`
- `make lint`
- `shfmt` 3.8.0 format check
- Isolated `make coverage-check`: Bash executable-line/function coverage 100%; Python campaign coverage 48.47% baseline satisfied

The repository's existing root `coverage/` report directory was not writable by the local user, so coverage validation used isolated temporary output directories.
