### PR TITLE
Add opt-in Hashcat integration

### DIFF
--- a/.github/workflows/hashcat-integration.yml
+++ b/.github/workflows/hashcat-integration.yml
@@ -1,0 +1,40 @@
+name: Hashcat Integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      device:
+        description: Hashcat device selector (for example, 1 or 1,2)
+        required: false
+        default: '1'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hashcat-integration
+  cancel-in-progress: false
+
+jobs:
+  hashcat-integration:
+    name: Real Hashcat smoke test
+    runs-on: [self-hosted, linux, x64, hashcat]
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify Hashcat backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v hashcat
+          hashcat --version
+          hashcat -I
+
+      - name: Run real Hashcat integration
+        env:
+          HASHCAT_INTEGRATION_DEVICE: ${{ inputs.device }}
+          HASHCAT_INTEGRATION_REQUIRE_GPU: '1'
+        run: make test-integration

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL_SOURCES := $(shell find . -type f -name '*.sh' ! -path './.git/*' ! -path 
 SHELLCHECK_VERSION ?= 0.10.0
 SHFMT_VERSION ?= 3.8.0
 
-.PHONY: verify-shellcheck verify-shfmt verify-tools lint format-check format qa test test-smoke test-campaign coverage coverage-python coverage-check
+.PHONY: verify-shellcheck verify-shfmt verify-tools lint format-check format qa test test-smoke test-campaign test-integration coverage coverage-python coverage-check
 
 verify-shellcheck:
 	@if ! command -v shellcheck >/dev/null 2>&1; then \
@@ -49,6 +49,10 @@ test-smoke:
 test-campaign:
 	@echo "Running campaign tests..."
 	@python3 -m unittest discover -s tests -p 'test_*.py'
+
+test-integration:
+	@echo "Running opt-in real Hashcat integration..."
+	@bash tests/integration.sh
 
 test: test-campaign test-smoke
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,30 @@ make coverage-python
 
 The Python report covers only first-party `scripts/campaign.py` logic and is written to `coverage/python/`. Its independent baseline is stored in `python-coverage-baseline.txt`; this keeps Bash and Python coverage metrics from being combined into a misleading single percentage.
 
+### Optional real Hashcat integration
+
+The default CI suite never starts Hashcat and does not require GPU hardware. An
+opt-in integration check is available for a Linux runner with a real Hashcat
+installation and OpenCL/CUDA backend:
+
+```bash
+HASHCAT_INTEGRATION_DEVICE=1 \
+HASHCAT_INTEGRATION_REQUIRE_GPU=1 \
+make test-integration
+```
+
+The check creates isolated temporary inputs, runs the real Hashcat-backed
+combinator path against a known MD5 test value, and verifies the cracked result
+in a temporary potfile. It does not use the developer configuration or modify
+repository data. `HASHCAT_INTEGRATION_REQUIRE_GPU=0` permits a CPU OpenCL
+backend for local validation.
+
+The manual [Hashcat Integration workflow](.github/workflows/hashcat-integration.yml)
+targets a trusted self-hosted Linux runner with the labels `self-hosted`,
+`linux`, `x64`, and `hashcat`. It is intentionally manual-only because real
+Hashcat execution and self-hosted runners are outside the deterministic default
+CI contract.
+
 ## Flags
 
 By default, `hash-cracker` enables optimized kernels, enables loopback, disables hardware monitoring, and shows cracked hashes on stdout.

--- a/VERSION.md
+++ b/VERSION.md
@@ -7,6 +7,7 @@
 - Added an independent Python campaign line-coverage report and baseline ratchet.
 - Added a manual workflow trigger and explicit ShellCheck/shfmt version verification for maintainer CI.
 - Added an operational audit-artifact policy for session logs and JSON statistics exports.
+- Added an opt-in real Hashcat integration check and manual self-hosted runner workflow.
 
 ### Changed
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ -n "${HASHCAT_INTEGRATION_HASHCAT:-}" ]; then
+    HASHCAT_BIN="$(command -v "$HASHCAT_INTEGRATION_HASHCAT" 2>/dev/null || true)"
+else
+    HASHCAT_BIN="$(command -v hashcat 2>/dev/null || true)"
+fi
+
+if [ -z "$HASHCAT_BIN" ] || [ ! -x "$HASHCAT_BIN" ]; then
+    echo "[integration] executable Hashcat is required; set HASHCAT_INTEGRATION_HASHCAT to its path." >&2
+    exit 1
+fi
+
+INTEGRATION_DEVICE="${HASHCAT_INTEGRATION_DEVICE:-1}"
+REQUIRE_GPU="${HASHCAT_INTEGRATION_REQUIRE_GPU:-0}"
+case "$REQUIRE_GPU" in
+    0 | 1) ;;
+    *)
+        echo "[integration] HASHCAT_INTEGRATION_REQUIRE_GPU must be 0 or 1." >&2
+        exit 1
+        ;;
+esac
+
+HASHCAT_VERSION="$($HASHCAT_BIN --version 2>&1 | head -n 1)"
+echo "[integration] $HASHCAT_VERSION"
+
+HASHCAT_INFO="$($HASHCAT_BIN -I 2>&1)" || {
+    echo "[integration] Hashcat backend discovery failed." >&2
+    printf '%s\n' "$HASHCAT_INFO" >&2
+    exit 1
+}
+
+if ! command -v script >/dev/null 2>&1; then
+    echo "[integration] the Linux 'script' utility is required to provide a terminal for Hashcat." >&2
+    exit 1
+fi
+
+if [ "$REQUIRE_GPU" = '1' ] && ! grep -Eq 'Type[. ]*:[[:space:]]+GPU' <<<"$HASHCAT_INFO"; then
+    echo "[integration] a GPU backend is required for this run, but Hashcat reported none." >&2
+    printf '%s\n' "$HASHCAT_INFO" >&2
+    exit 1
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/hash-cracker-integration.XXXXXX")"
+cleanup() {
+    rm -rf -- "$TMP_DIR"
+}
+trap cleanup EXIT
+
+INPUT_DIR="$TMP_DIR/inputs with spaces"
+LOG_DIR="$TMP_DIR/logs"
+HASHLIST="$INPUT_DIR/hashes.txt"
+POTFILE="$INPUT_DIR/potfile.txt"
+WORDLIST="$INPUT_DIR/first wordlist.txt"
+WORDLIST2="$INPUT_DIR/second wordlist.txt"
+CONFIG_PATH="$TMP_DIR/hash-cracker.conf"
+RUN_LOG="$TMP_DIR/run.log"
+HASH='5f4dcc3b5aa765d61d8327deb882cf99'
+
+mkdir -p "$INPUT_DIR" "$LOG_DIR" "$TMP_DIR/home"
+printf '%s\n' "$HASH" >"$HASHLIST"
+: >"$POTFILE"
+printf 'pass\n' >"$WORDLIST"
+printf 'word\n' >"$WORDLIST2"
+
+{
+    printf 'HASHCAT=(%q)\n' "$HASHCAT_BIN"
+    printf 'DEVICE=%q\n' "$INTEGRATION_DEVICE"
+    printf 'HASHTYPE=0\n'
+    printf 'HASHLIST=%q\n' "$HASHLIST"
+    printf 'POTFILE=%q\n' "$POTFILE"
+    printf 'WORDLIST=%q\n' "$WORDLIST"
+    printf 'WORDLIST2=%q\n' "$WORDLIST2"
+} >"$CONFIG_PATH"
+
+echo "[integration] running the real Hashcat combinator path"
+printf -v INTEGRATION_COMMAND 'env HOME=%q HASH_CRACKER_CONFIG=%q SESSION_LOG_DIR=%q NO_COLOR=1 START=8 ./hash-cracker.sh --job 8' \
+    "$TMP_DIR/home" "$CONFIG_PATH" "$LOG_DIR"
+if ! script -qefc "$INTEGRATION_COMMAND" "$RUN_LOG" >/dev/null 2>&1; then
+    echo "[integration] hash-cracker execution failed." >&2
+    cat "$RUN_LOG" >&2
+    exit 1
+fi
+
+if ! grep -Fxq "${HASH}:password" "$POTFILE"; then
+    echo "[integration] expected password was not written to the potfile." >&2
+    cat "$RUN_LOG" >&2
+    echo "[integration] potfile contents:" >&2
+    cat "$POTFILE" >&2
+    exit 1
+fi
+
+echo "[integration] real Hashcat execution passed"


### PR DESCRIPTION
## What changed

- Add `make test-integration` with an isolated real-Hashcat smoke fixture.
- Exercise the production wrapper through the combinator path using a known MD5 target and verify the temporary potfile result.
- Add a manual-only workflow for trusted self-hosted Linux runners with a GPU backend.
- Document the opt-in lane and record it in `VERSION.md` under Unreleased.

## Why

The default CI contract must remain deterministic and hardware-independent, but the project also benefits from one explicit end-to-end check against the real Hashcat executable and backend. This lane is isolated, manual-only, and never uses developer configuration or repository data.

## Validation

- `HASHCAT_INTEGRATION_REQUIRE_GPU=0 HASHCAT_INTEGRATION_DEVICE=1 make test-integration` (Hashcat v6.2.6, CPU OpenCL)
- `make test-smoke`
- `make test-campaign`
- `make lint`
- `shfmt` 3.8.0 check
- Workflow YAML parse check
- Isolated `make coverage-check`: Bash executable-line/function coverage 100%; Python campaign coverage 48.47% baseline satisfied

The GPU-required path is configured in the manual workflow and awaits a trusted self-hosted runner labeled `self-hosted`, `linux`, `x64`, and `hashcat`.
