### PR TITLE
Prepare v6.8.0 "Hardware Bridge"

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v6.8.0 - Hardware Bridge
+
 ### Added
 
 - Added an independent Python campaign line-coverage report and baseline ratchet.

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -52,7 +52,7 @@ function banner_center_line() {
 }
 
 function release_version_text() {
-    printf '%s' 'v6.7.0 "Execution Confidence"'
+    printf '%s' 'v6.8.0 "Hardware Bridge"'
 }
 
 function release_label_text() {

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1230,8 +1230,8 @@ run_case common_substring_helper_failure bash -lc "COMMON_SUBSTR_FAIL=1 ./hash-c
 assert_rc_eq 1
 assert_contains "Common-substring helper preprocessing failed."
 assert_not_contains "Substring processing done"
-if ! grep -Fq '"release": "v6.7.0 \"Execution Confidence\""' "$PRESET_STATS_EXPORT_PATH"; then
-    fail_with_log "preset stats export missing v6.7.0 release marker" "$PRESET_STATS_EXPORT_PATH"
+if ! grep -Fq '"release": "v6.8.0 \"Hardware Bridge\""' "$PRESET_STATS_EXPORT_PATH"; then
+    fail_with_log "preset stats export missing v6.8.0 release marker" "$PRESET_STATS_EXPORT_PATH"
 fi
 
 echo "[smoke] invalid --job selection fails clearly"


### PR DESCRIPTION
## What changed

- Prepare the next release as `v6.8.0 "Hardware Bridge"`.
- Move the accumulated Unreleased changelog entries into the v6.8.0 section.
- Update the runtime banner and exported release label.
- Update smoke coverage to assert the new release identity.

## Why

The merged audit-artifact policy, CI hardening, and opt-in real Hashcat integration lane form the next coherent release increment. This keeps the checked-in changelog, runtime output, and release tag aligned.

## Validation

- `make test`
- `make lint`
- `shfmt` 3.8.0 format check
- `COVERAGE_DIR=/tmp/hash-cracker-v680-coverage PYTHON_COVERAGE_DIR=/tmp/hash-cracker-v680-python-coverage make coverage-check`
- `HASHCAT_INTEGRATION_REQUIRE_GPU=0 HASHCAT_INTEGRATION_DEVICE=1 make test-integration`
- Latest merged Shell Quality CI run passed on the release base commit.

The GPU-required integration workflow remains manual-only and was not run because the configured GPU runner is currently unavailable.
