### PR TITLE
v6.9.0 "Private Artifact Lifecycle"

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v6.9.0 - Private Artifact Lifecycle
+
 ### Added
 
 - Added private per-campaign artifact workspaces with restrictive permissions,

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -53,7 +53,7 @@ function banner_center_line() {
 }
 
 function release_version_text() {
-    printf '%s' 'v6.8.0 "Hardware Bridge"'
+    printf '%s' 'v6.9.0 "Private Artifact Lifecycle"'
 }
 
 function release_label_text() {

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1330,8 +1330,8 @@ run_case common_substring_helper_failure bash -lc "COMMON_SUBSTR_FAIL=1 ./hash-c
 assert_rc_eq 1
 assert_contains "Common-substring helper preprocessing failed."
 assert_not_contains "Substring processing done"
-if ! grep -Fq '"release": "v6.8.0 \"Hardware Bridge\""' "$PRESET_STATS_EXPORT_PATH"; then
-    fail_with_log "preset stats export missing v6.8.0 release marker" "$PRESET_STATS_EXPORT_PATH"
+if ! grep -Fq '"release": "v6.9.0 \"Private Artifact Lifecycle\""' "$PRESET_STATS_EXPORT_PATH"; then
+    fail_with_log "preset stats export missing v6.9.0 release marker" "$PRESET_STATS_EXPORT_PATH"
 fi
 
 echo "[smoke] invalid --job selection fails clearly"


### PR DESCRIPTION
## What changed

- Updated the runtime release identity to `v6.9.0 "Private Artifact Lifecycle"`.
- Moved the completed private artifact lifecycle notes into the `v6.9.0` version section.
- Updated smoke coverage to assert the new exported release marker.

## Why

The merged private artifact lifecycle work is a user-visible release increment. This keeps the runtime banner, campaign metadata, statistics exports, tests, and version log aligned before the release tag is created.

## Validation

- `make test`
- `make lint`
- Pinned `shfmt` 3.8.0 check
- `COVERAGE_DIR=/tmp/hash-cracker-v690-coverage PYTHON_COVERAGE_DIR=/tmp/hash-cracker-v690-python-coverage make coverage-check`
- Bash coverage: 100.00%, baseline satisfied
- Python campaign coverage: 50.08%, baseline 48.47% satisfied
- `git diff --check`

After merge, publish tag `v6.9.0` with release name `v6.9.0 "Private Artifact Lifecycle"`.
