### PR TITLE
Fail-closed potfile validation

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,11 +11,12 @@ workflow remains local, deterministic, and GPU-optional.
   processor inputs, manifests, and campaign state receive restrictive creation
   modes; leaf symlink checks and legacy-manifest path compatibility are covered
   by regression tests.
+- **F2 — Fail-closed potfile validation (P2):** normal runs now require an
+  existing regular, readable, writable potfile and reject invalid paths before
+  Hashcat starts; dry-run handling remains non-mutating for a missing potfile.
 
 ## Planned
 
-- **F2 — Fail-closed potfile validation (P2):** reject missing, directory-valued,
-  unwritable, or uncreatable potfiles before Hashcat starts.
 - **F3 — Runtime contract validation (P2):** reject invalid processor modes and
   make self-test cover every job-specific helper, including Markov generation.
 - **F4 — Supported macOS portability (P2):** remove GNU-only filesystem

--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ chmod +x hash-cracker.sh
 At startup, `hash-cracker` checks that:
 
 - `HASHCAT` points to an executable `hashcat` binary
-- `POTFILE` exists, or can be created
+- `POTFILE` is an existing regular file with read/write access
 - the required config keys are set in `hash-cracker.conf`
+
+Normal runs fail before Hashcat starts if the potfile is missing, a directory,
+or cannot be read and written. Dry-run mode reports a missing potfile without
+creating or modifying it.
 
 ### Optional Dependencies
 
@@ -73,7 +77,7 @@ The file must live in the repository root and define these settings:
 - `DEVICE` - value passed to `hashcat -d`
 - `HASHTYPE` - hash mode, for example `1000` for NTLM
 - `HASHLIST` - file containing target hashes
-- `POTFILE` - potfile path to use or create
+- `POTFILE` - path to an existing readable/writable potfile
 - `WORDLIST` - primary wordlist path
 - `WORDLIST2` - secondary wordlist path used by combinator-style workflows
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Added fail-closed potfile validation before normal Hashcat execution.
+
 ## v6.9.0 - Private Artifact Lifecycle
 
 ### Added

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -1134,6 +1134,40 @@ function ensure_parent_dir() {
     return 0
 }
 
+function potfile_is_readable() {
+    [ -r "$1" ]
+}
+
+function potfile_is_writable() {
+    [ -w "$1" ]
+}
+
+function validate_potfile() {
+    local path="${1:-${POTFILE:-}}"
+
+    if [ -z "$path" ]; then
+        status_error "Potfile path is empty."
+        return 1
+    fi
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+        status_error "Potfile is missing: $path"
+        return 1
+    fi
+    if [ ! -f "$path" ]; then
+        status_error "Potfile is not a regular file: $path"
+        return 1
+    fi
+    if ! potfile_is_readable "$path"; then
+        status_error "Potfile is not readable: $path"
+        return 1
+    fi
+    if ! potfile_is_writable "$path"; then
+        status_error "Potfile is not writable: $path"
+        return 1
+    fi
+    return 0
+}
+
 function private_directory_owned() {
     [ -O "$1" ]
 }

--- a/scripts/parameters.sh
+++ b/scripts/parameters.sh
@@ -435,13 +435,12 @@ elif ! [ -x "$(command -v "$HASHCAT_BIN")" ]; then
 else
     status_ok "Hashcat is executable"
 fi
-if test -f "$POTFILE"; then
-    status_ok "Potfile $POTFILE present"
-elif [ "$DRYRUN" = ' ' ]; then
-    status_bad "Potfile not present, dry-run would create $POTFILE"
+if [ "$DRYRUN" = ' ' ] && [ ! -e "$POTFILE" ] && [ ! -L "$POTFILE" ]; then
+    status_bad "Potfile not present, dry-run will not create $POTFILE"
+elif validate_potfile "$POTFILE"; then
+    status_ok "Potfile $POTFILE is a readable, writable regular file"
 else
-    status_bad "Potfile not present, will create $POTFILE"
-    touch "$POTFILE"
+    ((COUNTER = COUNTER + 1))
 fi
 if [ "$COUNTER" -gt 0 ]; then
     status_error "Not all mandatory requirements are met. Please fix and try again."

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -154,6 +154,31 @@ printf 'hash:first\nhash:second\nhash:first\n' >"$HELPER_POTFILE"
 run_case helper_potfile_counts bash -lc "source ./hash-cracker.sh; POTFILE='$HELPER_POTFILE'; [ \"\$(count_potfile_unique_plaintexts)\" = 2 ] && POTFILE='$TMP_DIR/missing-helper-potfile' && [ \"\$(count_potfile_unique_plaintexts)\" = 0 ]"
 assert_rc_eq 0
 
+run_case helper_validate_potfile_success bash -lc "source ./hash-cracker.sh; validate_potfile '$TMP_DIR/hash-cracker.pot'"
+assert_rc_eq 0
+
+run_case helper_validate_potfile_empty bash -lc "source ./hash-cracker.sh; if validate_potfile ''; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+assert_contains "Potfile path is empty."
+
+run_case helper_validate_potfile_missing bash -lc "source ./hash-cracker.sh; if validate_potfile '$TMP_DIR/missing-validation-potfile'; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+assert_contains "Potfile is missing: $TMP_DIR/missing-validation-potfile"
+
+VALIDATION_DIRECTORY_POTFILE="$TMP_DIR/validation-directory-potfile"
+mkdir -p "$VALIDATION_DIRECTORY_POTFILE"
+run_case helper_validate_potfile_directory bash -lc "source ./hash-cracker.sh; if validate_potfile '$VALIDATION_DIRECTORY_POTFILE'; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+assert_contains "Potfile is not a regular file: $VALIDATION_DIRECTORY_POTFILE"
+
+run_case helper_validate_potfile_unreadable bash -lc "source ./hash-cracker.sh; potfile_is_readable() { return 1; }; if validate_potfile '$TMP_DIR/hash-cracker.pot'; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+assert_contains "Potfile is not readable: $TMP_DIR/hash-cracker.pot"
+
+run_case helper_validate_potfile_unwritable bash -lc "source ./hash-cracker.sh; potfile_is_writable() { return 1; }; if validate_potfile '$TMP_DIR/hash-cracker.pot'; then exit 1; else exit 0; fi"
+assert_rc_eq 0
+assert_contains "Potfile is not writable: $TMP_DIR/hash-cracker.pot"
+
 HELPER_PRUNE_DIR="$TMP_DIR/helper-prune"
 mkdir -p "$HELPER_PRUNE_DIR"
 touch "$HELPER_PRUNE_DIR/session-20200101-000000-1.log"
@@ -735,7 +760,7 @@ WORDLIST2=$TMP_DIR/wordlist2.txt
 EOF
 run_case missing_potfile bash -lc "./hash-cracker.sh --dry-run --job 1"
 assert_rc_eq 0
-assert_contains "Potfile not present, dry-run would create $MISSING_POTFILE"
+assert_contains "Potfile not present, dry-run will not create $MISSING_POTFILE"
 if [ -e "$MISSING_POTFILE" ]; then
     fail_with_log "dry-run unexpectedly created the missing potfile" "$LAST_LOG"
 fi
@@ -784,8 +809,9 @@ assert_rc_eq 1
 assert_contains "Hashcat is not available/executable"
 assert_contains "Not all mandatory requirements are met"
 
-NORMAL_MISSING_POTFILE="$TMP_DIR/normal-missing-potfile"
-rm -f -- "$NORMAL_MISSING_POTFILE"
+NORMAL_MISSING_POTFILE_PARENT="$TMP_DIR/normal-missing-parent"
+NORMAL_MISSING_POTFILE="$NORMAL_MISSING_POTFILE_PARENT/potfile"
+rm -rf -- "$NORMAL_MISSING_POTFILE_PARENT"
 cat >"$CONFIG_PATH" <<EOF
 HASHCAT=($TMP_DIR/fake-hashcat)
 DEVICE=1
@@ -796,11 +822,39 @@ WORDLIST=$TMP_DIR/wordlist.txt
 WORDLIST2=$TMP_DIR/wordlist2.txt
 EOF
 run_case normal_missing_potfile bash -lc "./hash-cracker.sh --job 1"
-assert_rc_eq 0
-assert_contains "Potfile not present, will create $NORMAL_MISSING_POTFILE"
-if [ ! -f "$NORMAL_MISSING_POTFILE" ]; then
-    fail_with_log "normal execution did not create the missing potfile" "$LAST_LOG"
+assert_rc_eq 1
+assert_contains "Potfile is missing: $NORMAL_MISSING_POTFILE"
+if [ -e "$NORMAL_MISSING_POTFILE_PARENT" ]; then
+    fail_with_log "normal execution unexpectedly created the missing potfile parent" "$LAST_LOG"
 fi
+
+NORMAL_DIRECTORY_POTFILE="$TMP_DIR/normal-directory-potfile"
+mkdir -p "$NORMAL_DIRECTORY_POTFILE"
+cat >"$CONFIG_PATH" <<EOF
+HASHCAT=($TMP_DIR/fake-hashcat)
+DEVICE=1
+HASHTYPE=1000
+HASHLIST=$TMP_DIR/input
+POTFILE=$NORMAL_DIRECTORY_POTFILE
+WORDLIST=$TMP_DIR/wordlist.txt
+WORDLIST2=$TMP_DIR/wordlist2.txt
+EOF
+run_case normal_directory_potfile bash -lc "./hash-cracker.sh --job 1"
+assert_rc_eq 1
+assert_contains "Potfile is not a regular file: $NORMAL_DIRECTORY_POTFILE"
+
+cat >"$CONFIG_PATH" <<EOF
+HASHCAT=($TMP_DIR/fake-hashcat)
+DEVICE=1
+HASHTYPE=1000
+HASHLIST=$TMP_DIR/input
+POTFILE=$TMP_DIR/hash-cracker.pot
+WORDLIST=$TMP_DIR/wordlist.txt
+WORDLIST2=$TMP_DIR/wordlist2.txt
+EOF
+run_case normal_unwritable_potfile bash -lc "source '$REPO_ROOT/hash-cracker.sh'; potfile_is_writable() { return 1; }; source '$REPO_ROOT/scripts/parameters.sh' --job 1"
+assert_rc_eq 1
+assert_contains "Potfile is not writable: $TMP_DIR/hash-cracker.pot"
 
 cat >"$CONFIG_PATH" <<EOF
 HASHCAT=($TMP_DIR/fake-hashcat)
@@ -2065,8 +2119,7 @@ assert_rc_eq 0
 assert_contains "Markov helper failed."
 
 BROKEN_POTFILE="$TMP_DIR/broken-potfile"
-: >"$BROKEN_POTFILE"
-chmod 000 "$BROKEN_POTFILE"
+mkdir -p "$BROKEN_POTFILE"
 cat >"$CONFIG_PATH" <<EOF
 HASHCAT=($TMP_DIR/fake-hashcat)
 DEVICE=1
@@ -2076,17 +2129,17 @@ POTFILE=$BROKEN_POTFILE
 WORDLIST=$TMP_DIR/wordlist.txt
 WORDLIST2=$TMP_DIR/wordlist2.txt
 EOF
-run_case processor_14_extraction_failure bash -lc "./hash-cracker.sh --job 14"
+run_case processor_14_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 14"
 assert_rc_eq 1
 assert_contains "Fingerprint plaintext extraction failed."
 
-run_case processor_9_extraction_failure bash -lc "./hash-cracker.sh --job 9"
+run_case processor_9_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 9"
 assert_rc_eq 1
 assert_contains "Iteration plaintext extraction failed."
-run_case processor_10_extraction_failure bash -lc "./hash-cracker.sh --job 10"
+run_case processor_10_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 10"
 assert_rc_eq 1
 assert_contains "Prefix/suffix plaintext extraction failed."
-run_case processor_11_extraction_failure bash -lc "./hash-cracker.sh --job 11"
+run_case processor_11_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 11"
 assert_rc_eq 1
 assert_contains "Common-substring plaintext extraction failed."
 run_case processor_12_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 12"
@@ -2095,8 +2148,8 @@ assert_contains "PACK rule plaintext extraction failed."
 run_case processor_13_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 13"
 assert_rc_eq 1
 assert_contains "PACK mask plaintext extraction failed."
-run_case processor_17_extraction_failure bash -lc "printf '17\np\n1\n1\n0\n' | ./hash-cracker.sh"
-assert_rc_eq 0
+run_case processor_17_extraction_failure bash -lc "printf 'p\n1\n1\n0\n' | (source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 17)"
+assert_rc_eq 1
 assert_contains "Markov source extraction failed."
 
 BROKEN_HASHLIST="$TMP_DIR/broken-hashlist"
@@ -2127,7 +2180,10 @@ WORDLIST2=$TMP_DIR/wordlist2.txt
 EOF
 run_case processor_19_missing_potfile_failure bash -lc "./hash-cracker.sh --job 19"
 assert_rc_eq 1
-assert_contains "Digit-removal source potfile is missing"
+assert_contains "Potfile is not a regular file: $MISSING_POTFILE"
+run_case processor_19_source_missing_potfile_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 19"
+assert_rc_eq 1
+assert_contains "Digit-removal source potfile is missing: $MISSING_POTFILE"
 
 printf 'hash:$HEX[zz]\n' >"$TMP_DIR/hash-cracker.pot"
 restore_config

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -2119,7 +2119,10 @@ assert_rc_eq 0
 assert_contains "Markov helper failed."
 
 BROKEN_POTFILE="$TMP_DIR/broken-potfile"
-mkdir -p "$BROKEN_POTFILE"
+# These direct processor tests bypass startup validation. Keep the input a
+# regular file and force awk to fail so extraction behavior is deterministic
+# across awk implementations.
+: >"$BROKEN_POTFILE"
 cat >"$CONFIG_PATH" <<EOF
 HASHCAT=($TMP_DIR/fake-hashcat)
 DEVICE=1
@@ -2129,26 +2132,26 @@ POTFILE=$BROKEN_POTFILE
 WORDLIST=$TMP_DIR/wordlist.txt
 WORDLIST2=$TMP_DIR/wordlist2.txt
 EOF
-run_case processor_14_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 14"
+run_case processor_14_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; awk() { return 1; }; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 14"
 assert_rc_eq 1
 assert_contains "Fingerprint plaintext extraction failed."
 
-run_case processor_9_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 9"
+run_case processor_9_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; awk() { return 1; }; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 9"
 assert_rc_eq 1
 assert_contains "Iteration plaintext extraction failed."
-run_case processor_10_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 10"
+run_case processor_10_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; awk() { return 1; }; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 10"
 assert_rc_eq 1
 assert_contains "Prefix/suffix plaintext extraction failed."
-run_case processor_11_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 11"
+run_case processor_11_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; awk() { return 1; }; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 11"
 assert_rc_eq 1
 assert_contains "Common-substring plaintext extraction failed."
-run_case processor_12_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 12"
+run_case processor_12_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; awk() { return 1; }; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 12"
 assert_rc_eq 1
 assert_contains "PACK rule plaintext extraction failed."
-run_case processor_13_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 13"
+run_case processor_13_extraction_failure bash -lc "source '$REPO_ROOT/hash-cracker.sh'; awk() { return 1; }; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 13"
 assert_rc_eq 1
 assert_contains "PACK mask plaintext extraction failed."
-run_case processor_17_extraction_failure bash -lc "printf 'p\n1\n1\n0\n' | (source '$REPO_ROOT/hash-cracker.sh'; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 17)"
+run_case processor_17_extraction_failure bash -lc "printf 'p\n1\n1\n0\n' | (source '$REPO_ROOT/hash-cracker.sh'; awk() { return 1; }; CONFIGFILE='$CONFIG_PATH'; STATICCONFIG=true; DRYRUN=''; MACHINE=Linux; run_processor 17)"
 assert_rc_eq 1
 assert_contains "Markov source extraction failed."
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -2555,10 +2555,10 @@ cat >"$CONFIG_PATH" <<EOF
 HASHCAT=($FAKE_HASHCAT)
 DEVICE=1
 HASHTYPE=1000
-HASHLIST=input
-POTFILE=hash-cracker.pot
-WORDLIST=wordlists/ignis-1M.txt
-WORDLIST2=wordlists/ignis-1K.txt
+HASHLIST=$TMP_DIR/input
+POTFILE=$TMP_DIR/hash-cracker.pot
+WORDLIST=$TMP_DIR/wordlist.txt
+WORDLIST2=$TMP_DIR/wordlist2.txt
 EOF
 
 rm -f "$CTRL_FIFO" "$CTRL_LOG" "$FAKE_PID_FILE"


### PR DESCRIPTION
## Summary

- Add fail-closed potfile validation before normal Hashcat execution.
- Reject missing, non-regular, unreadable, and unwritable potfiles without creating or mutating them.
- Preserve non-mutating dry-run behavior for a missing potfile.
- Add focused validation coverage and update the README, version notes, and backlog.

## Why

Normal startup previously attempted to create a missing potfile and continued even when creation failed. That allowed an invalid runtime configuration to reach later session or processor logic. The new startup gate reports the exact potfile problem and stops before Hashcat starts.

## Validation

- `make test-smoke`
- `make test-campaign`
- `make lint`
- Bash coverage: 100.00% executable-line and function coverage; baseline satisfied

All tests use isolated fixtures and fake dependencies; no GPU, real Hashcat execution, network access, or developer-local configuration is required.
